### PR TITLE
DVX-TK-027 Edit holding from security detail

### DIFF
--- a/common/currency/src/commonMain/kotlin/com/akole/dividox/common/currency/CurrencyConverter.kt
+++ b/common/currency/src/commonMain/kotlin/com/akole/dividox/common/currency/CurrencyConverter.kt
@@ -31,6 +31,9 @@ class CurrencyConverter(
      */
     suspend fun convert(amount: Double, from: Currency, to: Currency): Result<Double> {
         if (from == to) return Result.success(amount)
+        // GBX (pence) = 1/100 GBP — no exchange rate lookup needed for this step.
+        if (from == Currency.GBX) return convert(amount * 0.01, Currency.GBP, to)
+        if (to == Currency.GBX) return convert(amount, from, Currency.GBP).map { it * 100.0 }
         return getExchangeRates(from).mapCatching { rates ->
             rates.rates[to] ?: error("No exchange rate found for ${to.code} (base: ${from.code})")
         }.map { rate -> amount * rate }

--- a/common/currency/src/commonMain/kotlin/com/akole/dividox/common/currency/domain/model/Currency.kt
+++ b/common/currency/src/commonMain/kotlin/com/akole/dividox/common/currency/domain/model/Currency.kt
@@ -13,6 +13,8 @@ enum class Currency(val code: String, val symbol: String) {
     USD("USD", "$"),
     EUR("EUR", "€"),
     GBP("GBP", "£"),
+    /** British pence — 100 GBX = 1 GBP. Used for stocks quoted on LSE in pence. */
+    GBX("GBX", "p"),
     JPY("JPY", "¥"),
     CHF("CHF", "CHF "),
     CAD("CAD", "CA$"),

--- a/common/ui-resources/src/commonMain/composeResources/values/strings.xml
+++ b/common/ui-resources/src/commonMain/composeResources/values/strings.xml
@@ -63,7 +63,7 @@
     <string name="label_price_per_share">Price per Share</string>
     <string name="label_purchase_date">Purchase Date</string>
     <string name="label_estimated_value">Estimated Value</string>
-    <string name="search_security_hint">Search security (ticker or name)</string>
+    <string name="search_security_hint">Filter security (ticker or name)</string>
     <string name="dialog_remove_title">Remove Position?</string>
     <string name="dialog_remove_message">Remove %1$s from your portfolio? This cannot be undone.</string>
     <string name="cd_delete">Delete</string>

--- a/common/ui-resources/src/commonMain/composeResources/values/strings.xml
+++ b/common/ui-resources/src/commonMain/composeResources/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="cd_add_to_favourites">Add to favourites</string>
     <string name="label_in_portfolio">In portfolio</string>
     <string name="security_type_all">All</string>
+    <string name="security_type_equity">Stock</string>
     <string name="security_type_etf">ETF</string>
     <string name="security_type_fund">Fund</string>
     <string name="cd_clear_search">Clear search</string>

--- a/common/ui-resources/src/commonMain/composeResources/values/strings.xml
+++ b/common/ui-resources/src/commonMain/composeResources/values/strings.xml
@@ -43,6 +43,9 @@
     <string name="cd_remove_from_favourites">Remove from favourites</string>
     <string name="cd_add_to_favourites">Add to favourites</string>
     <string name="label_in_portfolio">In portfolio</string>
+    <string name="security_type_all">All</string>
+    <string name="security_type_etf">ETF</string>
+    <string name="security_type_fund">Fund</string>
     <string name="cd_clear_search">Clear search</string>
     <string name="favorites_title">Favourites</string>
     <string name="disclaimer_prices_delayed">Prices delayed 15 minutes</string>

--- a/common/ui-resources/src/commonMain/composeResources/values/strings.xml
+++ b/common/ui-resources/src/commonMain/composeResources/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="label_purchase_date">Purchase Date</string>
     <string name="label_estimated_value">Estimated Value</string>
     <string name="search_security_hint">Filter security (ticker or name)</string>
+    <string name="holding_search_security_hint">Search security (ticker or name)</string>
     <string name="dialog_remove_title">Remove Position?</string>
     <string name="dialog_remove_message">Remove %1$s from your portfolio? This cannot be undone.</string>
     <string name="cd_delete">Delete</string>

--- a/common/ui-resources/src/commonMain/kotlin/com/akole/dividox/common/ui/resources/components/ExchangeMarket.kt
+++ b/common/ui-resources/src/commonMain/kotlin/com/akole/dividox/common/ui/resources/components/ExchangeMarket.kt
@@ -1,0 +1,26 @@
+package com.akole.dividox.common.ui.resources.components
+
+enum class ExchangeMarket(
+    val emoji: String,
+    val label: String,
+    val region: String?,
+    private val keywords: Set<String>,
+) {
+    ALL("🌍", "All", null, emptySet()),
+    US("🇺🇸", "US", "US", setOf("NASDAQ", "NYSE", "AMEX", "OTC", "ARCA", "PCX")),
+    UK("🇬🇧", "UK", "GB", setOf("LSE", "LONDON", "LON")),
+    DE("🇩🇪", "DE", "DE", setOf("XETRA", "FSX", "FRA", "GER")),
+    ES("🇪🇸", "ES", "ES", setOf("BME", "MCE", "MAD", "MADRID")),
+    FR("🇫🇷", "FR", "FR", setOf("PAR", "EPA", "ENX", "PARIS")),
+    IT("🇮🇹", "IT", "IT", setOf("MIL", "BIT", "MILAN")),
+    CA("🇨🇦", "CA", "CA", setOf("TSX", "CVE", "TORONTO")),
+    AU("🇦🇺", "AU", "AU", setOf("ASX", "SYDNEY")),
+    JP("🇯🇵", "JP", "JP", setOf("TSE", "OSE", "TOKYO")),
+    ;
+
+    fun matches(exchange: String?): Boolean {
+        if (this == ALL) return true
+        val upper = exchange?.uppercase() ?: return false
+        return keywords.any { upper.contains(it) }
+    }
+}

--- a/common/ui-resources/src/commonMain/kotlin/com/akole/dividox/common/ui/resources/components/MarketFilterRow.kt
+++ b/common/ui-resources/src/commonMain/kotlin/com/akole/dividox/common/ui/resources/components/MarketFilterRow.kt
@@ -1,0 +1,40 @@
+package com.akole.dividox.common.ui.resources.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.akole.dividox.common.ui.resources.theme.spacing
+
+@Composable
+fun MarketFilterRow(
+    selectedMarket: ExchangeMarket,
+    onMarketSelected: (ExchangeMarket) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(horizontal = MaterialTheme.spacing.medium),
+) {
+    LazyRow(
+        modifier = modifier,
+        contentPadding = contentPadding,
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small),
+    ) {
+        items(ExchangeMarket.entries, key = { it.name }) { market ->
+            FilterChip(
+                selected = selectedMarket == market,
+                onClick = { onMarketSelected(market) },
+                label = {
+                    Text(
+                        text = "${market.emoji} ${market.label}",
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                },
+            )
+        }
+    }
+}

--- a/common/ui-resources/src/commonMain/kotlin/com/akole/dividox/common/ui/resources/components/SearchBar.kt
+++ b/common/ui-resources/src/commonMain/kotlin/com/akole/dividox/common/ui/resources/components/SearchBar.kt
@@ -30,6 +30,7 @@ fun SearchBar(
     placeholder: String,
     modifier: Modifier = Modifier,
     autoFocus: Boolean = false,
+    enabled: Boolean = true,
 ) {
     val focusRequester = remember { FocusRequester() }
     if (autoFocus) {
@@ -38,6 +39,7 @@ fun SearchBar(
     TextField(
         value = query,
         onValueChange = onQueryChange,
+        enabled = enabled,
         modifier = modifier.fillMaxWidth().focusRequester(focusRequester),
         placeholder = {
             Text(
@@ -72,6 +74,7 @@ fun SearchBar(
             disabledIndicatorColor = Color.Transparent,
             focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
             unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+            disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
         ),
         textStyle = MaterialTheme.typography.bodyMedium,
     )

--- a/common/ui-resources/src/commonMain/kotlin/com/akole/dividox/common/ui/resources/components/SecurityCard.kt
+++ b/common/ui-resources/src/commonMain/kotlin/com/akole/dividox/common/ui/resources/components/SecurityCard.kt
@@ -48,6 +48,7 @@ fun SecurityCard(
     onFavoriteToggle: () -> Unit,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    securityType: String? = null,
 ) {
     Card(
         modifier = modifier
@@ -66,11 +67,23 @@ fun SecurityCard(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = ticker,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold,
-                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xSmall),
+                ) {
+                    Text(
+                        text = ticker,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    if (securityType != null) {
+                        Text(
+                            text = securityType,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
                 if (companyName != null) {
                     Text(
                         text = companyName,

--- a/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/api/YahooFinanceApi.kt
+++ b/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/api/YahooFinanceApi.kt
@@ -50,10 +50,12 @@ internal class YahooFinanceApi(
      *
      * @param query Free-text search string (ticker or company name).
      */
-    suspend fun search(query: String): SearchResponseDto =
+    suspend fun search(query: String, region: String? = null): SearchResponseDto =
         client.get("https://query1.finance.yahoo.com/v1/finance/search") {
             parameter("q", query)
             parameter("quotesCount", 10)
             parameter("newsCount", 0)
+            parameter("enableFuzzyQuery", true)
+            if (region != null) parameter("region", region)
         }.body()
 }

--- a/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/mapper/ChartMapper.kt
+++ b/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/mapper/ChartMapper.kt
@@ -24,29 +24,40 @@ private const val DAYS_PER_YEAR_PRECISE = 365.25
 /** Unix seconds in one calendar year (non-leap). */
 private const val ONE_YEAR_SECONDS = DAYS_PER_YEAR * HOURS_PER_DAY * SECONDS_PER_HOUR
 
+// Yahoo Finance returns "GBX" (pence) for LSE stocks. Normalize to GBP at the API boundary.
+private const val GBX = "GBX"
+private const val GBP = "GBP"
+private const val PENCE_TO_POUNDS = 0.01
+
+private val ChartMetaDto.priceFactor: Double get() = if (currency == GBX) PENCE_TO_POUNDS else 1.0
+private val ChartMetaDto.normalizedCurrency: String get() = if (currency == GBX) GBP else (currency ?: "USD")
+
 /**
  * Maps chart metadata to a [StockQuote].
  *
  * Change and changePercent are derived from [ChartMetaDto.chartPreviousClose].
  * If previous close is unavailable, change values default to 0.
+ * GBX (pence) prices are normalized to GBP by dividing by 100.
  */
 internal fun ChartMetaDto.toStockQuote(): StockQuote {
-    val previousClose = chartPreviousClose ?: regularMarketPrice
-    val change = regularMarketPrice - previousClose
+    val factor = priceFactor
+    val price = regularMarketPrice * factor
+    val previousClose = (chartPreviousClose ?: regularMarketPrice) * factor
+    val change = price - previousClose
     val changePercent = if (previousClose != 0.0) (change / previousClose) * 100.0 else 0.0
     return StockQuote(
         ticker = symbol,
-        price = regularMarketPrice,
+        price = price,
         change = change,
         changePercent = changePercent,
-        currency = currency ?: "USD",
+        currency = normalizedCurrency,
         lastUpdated = Instant.fromEpochSeconds(regularMarketTime ?: 0),
         name = longName ?: shortName,
-        fiftyTwoWeekHigh = fiftyTwoWeekHigh,
-        fiftyTwoWeekLow = fiftyTwoWeekLow,
+        fiftyTwoWeekHigh = fiftyTwoWeekHigh?.times(factor),
+        fiftyTwoWeekLow = fiftyTwoWeekLow?.times(factor),
         volume = regularMarketVolume,
-        dayHigh = regularMarketDayHigh,
-        dayLow = regularMarketDayLow,
+        dayHigh = regularMarketDayHigh?.times(factor),
+        dayLow = regularMarketDayLow?.times(factor),
     )
 }
 
@@ -63,13 +74,14 @@ internal fun ChartMetaDto.toStockQuote(): StockQuote {
  * @param ticker Yahoo Finance symbol used as the [DividendInfo.ticker] key.
  */
 internal fun ChartResultDto.toDividendInfo(ticker: String): DividendInfo {
-    val price = meta.regularMarketPrice
+    val factor = meta.priceFactor
+    val price = meta.regularMarketPrice * factor
     val nowSeconds = Clock.System.now().epochSeconds
     val dividends = events?.dividends?.values?.sortedBy { it.date } ?: emptyList()
     val past = dividends.filter { it.date <= nowSeconds }
     val future = dividends.filter { it.date > nowSeconds }
 
-    val annualPayout = calculateAnnualPayout(dividends)
+    val annualPayout = calculateAnnualPayout(dividends) * factor
     val yieldValue = if (price > 0.0) (annualPayout / price) * 100.0 else 0.0
     val fiveYearGrowth = calculateFiveYearGrowth(past.ifEmpty { dividends })
 
@@ -161,11 +173,12 @@ internal fun ChartResultDto.toCompanyInfo(ticker: String): CompanyInfo = Company
  * Candles with a `null` closing price (market holidays, partial trading days) are skipped.
  */
 internal fun ChartResultDto.toPricePoints(): List<PricePoint> {
+    val factor = meta.priceFactor
     val timestamps = timestamp ?: return emptyList()
     val closes = indicators?.quote?.firstOrNull()?.close ?: return emptyList()
     return timestamps.zip(closes)
         .mapNotNull { (ts, close) ->
-            close?.let { PricePoint(timestamp = Instant.fromEpochSeconds(ts), close = it) }
+            close?.let { PricePoint(timestamp = Instant.fromEpochSeconds(ts), close = it * factor) }
         }
 }
 
@@ -179,14 +192,15 @@ internal fun ChartResultDto.toPricePoints(): List<PricePoint> {
  * @param ticker Yahoo Finance symbol used as the [MarketDividendEvent.ticker] key.
  */
 internal fun ChartResultDto.toMarketDividendEvents(ticker: String): List<MarketDividendEvent> {
-    val currency = meta.currency ?: "USD"
+    val factor = meta.priceFactor
+    val currency = meta.normalizedCurrency
     return events?.dividends
         ?.values
         ?.sortedBy { it.date }
         ?.map { dto ->
             MarketDividendEvent(
                 ticker = ticker,
-                amountPerShare = dto.amount,
+                amountPerShare = dto.amount * factor,
                 exDividendDate = Instant.fromEpochSeconds(dto.date)
                     .toLocalDateTime(TimeZone.UTC).date,
                 currency = currency,

--- a/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/mapper/ChartMapper.kt
+++ b/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/mapper/ChartMapper.kt
@@ -24,13 +24,14 @@ private const val DAYS_PER_YEAR_PRECISE = 365.25
 /** Unix seconds in one calendar year (non-leap). */
 private const val ONE_YEAR_SECONDS = DAYS_PER_YEAR * HOURS_PER_DAY * SECONDS_PER_HOUR
 
-// Yahoo Finance returns "GBX" (pence) for LSE stocks. Normalize to GBP at the API boundary.
-private const val GBX = "GBX"
+// Yahoo Finance returns "GBp" (pence) for LSE stocks; some providers use "GBX".
+// Both represent British pence (100p = £1). Normalize to GBP at the API boundary.
 private const val GBP = "GBP"
 private const val PENCE_TO_POUNDS = 0.01
 
-private val ChartMetaDto.priceFactor: Double get() = if (currency == GBX) PENCE_TO_POUNDS else 1.0
-private val ChartMetaDto.normalizedCurrency: String get() = if (currency == GBX) GBP else (currency ?: "USD")
+private fun String?.isGBPence(): Boolean = this == "GBX" || this == "GBp"
+private val ChartMetaDto.priceFactor: Double get() = if (currency.isGBPence()) PENCE_TO_POUNDS else 1.0
+private val ChartMetaDto.normalizedCurrency: String get() = if (currency.isGBPence()) GBP else (currency ?: "USD")
 
 /**
  * Maps chart metadata to a [StockQuote].

--- a/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImpl.kt
+++ b/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImpl.kt
@@ -133,9 +133,9 @@ class MarketRepositoryImpl(
             emit(result?.toPricePoints() ?: emptyList())
         }.flowOn(ioDispatcher)
 
-    override suspend fun searchSecurities(query: String): Result<List<StockQuote>> = withContext(ioDispatcher) {
+    override suspend fun searchSecurities(query: String, region: String?): Result<List<StockQuote>> = withContext(ioDispatcher) {
         runCatching {
-            val dto = api.search(query)
+            val dto = api.search(query, region)
             val acceptedTypes = setOf("EQUITY", "ETF", "MUTUALFUND")
             dto.quotes
                 ?.filter { it.quoteType?.uppercase() in acceptedTypes }

--- a/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImpl.kt
+++ b/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.akole.dividox.component.market.data.mapper.toMarketDividendEvents
 import com.akole.dividox.component.market.data.mapper.toPricePoints
 import com.akole.dividox.component.market.data.mapper.toStockQuote
 import com.akole.dividox.component.market.domain.model.ChartPeriod
+import com.akole.dividox.component.market.domain.model.SecurityType
 import com.akole.dividox.component.market.domain.model.CompanyInfo
 import com.akole.dividox.component.market.domain.model.DividendHistoryRange
 import com.akole.dividox.component.market.domain.model.DividendInfo
@@ -136,7 +137,7 @@ class MarketRepositoryImpl(
     override suspend fun searchSecurities(query: String, region: String?): Result<List<StockQuote>> = withContext(ioDispatcher) {
         runCatching {
             val dto = api.search(query, region)
-            val acceptedTypes = setOf("EQUITY")
+            val acceptedTypes = setOf("EQUITY", "ETF", "MUTUALFUND")
             dto.quotes
                 ?.filter { it.quoteType?.uppercase() in acceptedTypes }
                 ?.map { quote ->
@@ -149,6 +150,11 @@ class MarketRepositoryImpl(
                         lastUpdated = Clock.System.now(),
                         name = quote.shortname ?: quote.longname,
                         exchange = quote.exchDisp,
+                        type = when (quote.quoteType?.uppercase()) {
+                            "ETF" -> SecurityType.ETF
+                            "MUTUALFUND" -> SecurityType.MUTUAL_FUND
+                            else -> null
+                        },
                     )
                 }
                 ?.sortedBy { exchangePriority(it.exchange) }

--- a/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImpl.kt
+++ b/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImpl.kt
@@ -151,9 +151,10 @@ class MarketRepositoryImpl(
                         name = quote.shortname ?: quote.longname,
                         exchange = quote.exchDisp,
                         type = when (quote.quoteType?.uppercase()) {
+                            "EQUITY" -> SecurityType.EQUITY
                             "ETF" -> SecurityType.ETF
                             "MUTUALFUND" -> SecurityType.MUTUAL_FUND
-                            else -> null
+                            else -> SecurityType.EQUITY
                         },
                     )
                 }

--- a/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImpl.kt
+++ b/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImpl.kt
@@ -136,7 +136,7 @@ class MarketRepositoryImpl(
     override suspend fun searchSecurities(query: String, region: String?): Result<List<StockQuote>> = withContext(ioDispatcher) {
         runCatching {
             val dto = api.search(query, region)
-            val acceptedTypes = setOf("EQUITY", "ETF", "MUTUALFUND")
+            val acceptedTypes = setOf("EQUITY")
             dto.quotes
                 ?.filter { it.quoteType?.uppercase() in acceptedTypes }
                 ?.map { quote ->

--- a/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImpl.kt
+++ b/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImpl.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import kotlin.time.Clock
 
@@ -32,6 +34,9 @@ class MarketRepositoryImpl(
 ) : MarketRepository {
 
     private val api = YahooFinanceApi(httpClient)
+
+    // Limits concurrent Yahoo Finance requests to avoid rate-limiting on large portfolios.
+    private val apiSemaphore = Semaphore(MAX_CONCURRENT_REQUESTS)
 
     private val quoteCache = mutableMapOf<String, Pair<StockQuote, Long>>()
     private val dividendCache = mutableMapOf<String, Pair<DividendInfo, Long>>()
@@ -64,15 +69,22 @@ class MarketRepositoryImpl(
                             toFetch += ticker
                         }
                     }
+                    // Semaphore caps concurrent requests to avoid Yahoo Finance rate-limiting.
+                    // Per-ticker runCatching means one failed ticker doesn't kill the whole batch.
                     val fromApi = toFetch
-                        .map { ticker -> async { api.getChart(ticker) to ticker } }
-                        .map { deferred ->
-                            val (dto, ticker) = deferred.await()
+                        .map { ticker ->
+                            async {
+                                apiSemaphore.withPermit {
+                                    runCatching { api.getChart(ticker) to ticker }.getOrNull()
+                                }
+                            }
+                        }
+                        .mapNotNull { deferred ->
+                            val (dto, ticker) = deferred.await() ?: return@mapNotNull null
                             dto.chart.result?.firstOrNull()?.meta
                                 ?.toStockQuote()
                                 ?.also { quote -> quoteCache[ticker] = quote to now }
                         }
-                        .filterNotNull()
                     fromCache + fromApi
                 }
             }.mapError()
@@ -81,12 +93,14 @@ class MarketRepositoryImpl(
     override suspend fun getDividendInfo(ticker: String): Result<DividendInfo> = withContext(ioDispatcher) {
         val cached = dividendCache[ticker]
         if (cached != null && !isExpired(cached.second, DIVIDEND_TTL_MS)) return@withContext Result.success(cached.first)
-        runCatching {
-            val dto = api.getChartWithEvents(ticker)
-            val result = dto.chart.result?.firstOrNull()
-                ?: throw MarketError.NotFound(ticker)
-            result.toDividendInfo(ticker).also { dividendCache[ticker] = it to Clock.System.now().toEpochMilliseconds() }
-        }.mapError()
+        apiSemaphore.withPermit {
+            runCatching {
+                val dto = api.getChartWithEvents(ticker)
+                val result = dto.chart.result?.firstOrNull()
+                    ?: throw MarketError.NotFound(ticker)
+                result.toDividendInfo(ticker).also { dividendCache[ticker] = it to Clock.System.now().toEpochMilliseconds() }
+            }.mapError()
+        }
     }
 
     override suspend fun getCompanyInfo(ticker: String): Result<CompanyInfo> = withContext(ioDispatcher) {
@@ -184,6 +198,7 @@ class MarketRepositoryImpl(
         private const val QUOTE_TTL_MS = 300_000L              // 5 minutes
         private const val DIVIDEND_TTL_MS = 3_600_000L         // 1 hour
         private const val HISTORICAL_DIVIDEND_TTL_MS = 86_400_000L  // 24 hours
+        private const val MAX_CONCURRENT_REQUESTS = 8
 
         /**
          * Main exchange tiers, ordered from highest to lowest priority.

--- a/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/domain/model/SecurityType.kt
+++ b/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/domain/model/SecurityType.kt
@@ -1,6 +1,7 @@
 package com.akole.dividox.component.market.domain.model
 
 enum class SecurityType {
+    EQUITY,
     ETF,
     MUTUAL_FUND,
 }

--- a/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/domain/model/SecurityType.kt
+++ b/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/domain/model/SecurityType.kt
@@ -1,0 +1,6 @@
+package com.akole.dividox.component.market.domain.model
+
+enum class SecurityType {
+    ETF,
+    MUTUAL_FUND,
+}

--- a/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/domain/model/StockQuote.kt
+++ b/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/domain/model/StockQuote.kt
@@ -13,6 +13,8 @@ data class StockQuote(
     val name: String? = null,
     /** Exchange display name (e.g. "NASDAQ", "NYSE"), populated only from search results. */
     val exchange: String? = null,
+    /** Security type for filtering and display. Null for plain equities. */
+    val type: SecurityType? = null,
     val fiftyTwoWeekHigh: Double? = null,
     val fiftyTwoWeekLow: Double? = null,
     val volume: Long? = null,

--- a/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/domain/repository/MarketRepository.kt
+++ b/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/domain/repository/MarketRepository.kt
@@ -32,5 +32,5 @@ interface MarketRepository {
     ): Result<List<MarketDividendEvent>>
 
     fun getPriceHistory(ticker: String, period: ChartPeriod): Flow<List<PricePoint>>
-    suspend fun searchSecurities(query: String): Result<List<StockQuote>>
+    suspend fun searchSecurities(query: String, region: String? = null): Result<List<StockQuote>>
 }

--- a/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/domain/usecase/SearchSecuritiesUseCase.kt
+++ b/component/market/src/commonMain/kotlin/com/akole/dividox/component/market/domain/usecase/SearchSecuritiesUseCase.kt
@@ -4,6 +4,6 @@ import com.akole.dividox.component.market.domain.model.StockQuote
 import com.akole.dividox.component.market.domain.repository.MarketRepository
 
 class SearchSecuritiesUseCase(private val repository: MarketRepository) {
-    suspend operator fun invoke(query: String): Result<List<StockQuote>> =
-        repository.searchSecurities(query)
+    suspend operator fun invoke(query: String, region: String? = null): Result<List<StockQuote>> =
+        repository.searchSecurities(query, region)
 }

--- a/component/market/src/commonTest/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImplTest.kt
+++ b/component/market/src/commonTest/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImplTest.kt
@@ -247,6 +247,35 @@ class MarketRepositoryImplTest {
         assertEquals(52.50, points.last().close, 0.001)
     }
 
+    @Test
+    fun `SHOULD normalize GBp price to GBP WHEN currency is GBp GIVEN Yahoo Finance LSE stock`() = runTest(dispatcher) {
+        // GIVEN — LGEN.L at 210.68 GBp (pence) = £2.1068; Yahoo Finance uses "GBp" not "GBX"
+        val repo = buildRepoWithResponses("chart" to CHART_JSON_LGEN)
+
+        // WHEN
+        val quote = repo.getStockQuote("LGEN.L").getOrThrow()
+
+        // THEN
+        assertEquals("GBP", quote.currency)
+        assertEquals(2.1068, quote.price, 0.001)
+        assertEquals(2.5, quote.fiftyTwoWeekHigh!!, 0.001)  // 250 GBp → £2.50
+        assertEquals(1.8, quote.fiftyTwoWeekLow!!, 0.001)   // 180 GBp → £1.80
+    }
+
+    @Test
+    fun `SHOULD normalize GBp price points to GBP WHEN currency is GBp GIVEN Yahoo Finance chart`() = runTest(dispatcher) {
+        // GIVEN
+        val repo = buildRepoWithResponses("chart" to CHART_JSON_LGEN)
+
+        // WHEN
+        val points = repo.getPriceHistory("LGEN.L", ChartPeriod.ONE_MONTH).first()
+
+        // THEN — 200.0 GBp → £2.00, 210.68 GBp → £2.1068
+        assertEquals(2, points.size)
+        assertEquals(2.0, points.first().close, 0.001)
+        assertEquals(2.1068, points.last().close, 0.001)
+    }
+
     // ── searchSecurities ──────────────────────────────────────────────────────
 
     @Test
@@ -373,6 +402,31 @@ class MarketRepositoryImplTest {
                   "timestamp": [1700000000, 1700086400],
                   "indicators": {
                     "quote": [{ "close": [5200.0, 5250.0] }]
+                  }
+                }],
+                "error": null
+              }
+            }
+        """.trimIndent()
+
+        // Yahoo Finance actually returns "GBp" (not "GBX") for most LSE stocks
+        val CHART_JSON_LGEN = """
+            {
+              "chart": {
+                "result": [{
+                  "meta": {
+                    "symbol": "LGEN.L",
+                    "regularMarketPrice": 210.68,
+                    "chartPreviousClose": 208.0,
+                    "currency": "GBp",
+                    "regularMarketTime": 1700000000,
+                    "exchangeName": "LSE",
+                    "fiftyTwoWeekHigh": 250.0,
+                    "fiftyTwoWeekLow": 180.0
+                  },
+                  "timestamp": [1700000000, 1700086400],
+                  "indicators": {
+                    "quote": [{ "close": [200.0, 210.68] }]
                   }
                 }],
                 "error": null

--- a/component/market/src/commonTest/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImplTest.kt
+++ b/component/market/src/commonTest/kotlin/com/akole/dividox/component/market/data/repository/MarketRepositoryImplTest.kt
@@ -216,6 +216,37 @@ class MarketRepositoryImplTest {
         assertEquals(150.0, points.last().close)
     }
 
+    // ── GBX normalization ─────────────────────────────────────────────────────
+
+    @Test
+    fun `SHOULD normalize GBX price to GBP WHEN currency is GBX GIVEN LSE stock`() = runTest(dispatcher) {
+        // GIVEN — Lloyds at 5250 GBX (pence) = £52.50
+        val repo = buildRepoWithResponses("chart" to CHART_JSON_LLOY)
+
+        // WHEN
+        val quote = repo.getStockQuote("LLOY.L").getOrThrow()
+
+        // THEN
+        assertEquals("GBP", quote.currency)
+        assertEquals(52.50, quote.price, 0.001)
+        assertEquals(60.0, quote.fiftyTwoWeekHigh!!, 0.001)  // 6000 GBX → £60
+        assertEquals(45.0, quote.fiftyTwoWeekLow!!, 0.001)   // 4500 GBX → £45
+    }
+
+    @Test
+    fun `SHOULD normalize GBX price points to GBP WHEN currency is GBX GIVEN chart with history`() = runTest(dispatcher) {
+        // GIVEN
+        val repo = buildRepoWithResponses("chart" to CHART_JSON_LLOY)
+
+        // WHEN
+        val points = repo.getPriceHistory("LLOY.L", ChartPeriod.ONE_MONTH).first()
+
+        // THEN — 5200 GBX → £52, 5250 GBX → £52.50
+        assertEquals(2, points.size)
+        assertEquals(52.0, points.first().close, 0.001)
+        assertEquals(52.50, points.last().close, 0.001)
+    }
+
     // ── searchSecurities ──────────────────────────────────────────────────────
 
     @Test
@@ -319,6 +350,30 @@ class MarketRepositoryImplTest {
                     "exchangeName": "NMS"
                   },
                   "events": {}
+                }],
+                "error": null
+              }
+            }
+        """.trimIndent()
+
+        val CHART_JSON_LLOY = """
+            {
+              "chart": {
+                "result": [{
+                  "meta": {
+                    "symbol": "LLOY.L",
+                    "regularMarketPrice": 5250.0,
+                    "chartPreviousClose": 5200.0,
+                    "currency": "GBX",
+                    "regularMarketTime": 1700000000,
+                    "exchangeName": "LSE",
+                    "fiftyTwoWeekHigh": 6000.0,
+                    "fiftyTwoWeekLow": 4500.0
+                  },
+                  "timestamp": [1700000000, 1700086400],
+                  "indicators": {
+                    "quote": [{ "close": [5200.0, 5250.0] }]
+                  }
                 }],
                 "error": null
               }

--- a/composeApp/src/commonMain/kotlin/com/akole/dividox/di/ViewModelModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/akole/dividox/di/ViewModelModule.kt
@@ -54,10 +54,12 @@ val viewModelModule: Module = module {
 
     // HoldingViewModel with optional holdingId parameter for Add/Edit modes
     viewModel { params ->
-        val holdingIdValue: String? = params.getOrNull()
+        val holdingIdValue: String? = params.component1()
+        val prefillTicker: String? = if (params.size() > 1) params.component2() else null
         val holdingId = holdingIdValue?.let { HoldingId(it) }
         HoldingViewModel(
             holdingId = holdingId,
+            prefillTicker = prefillTicker,
             searchSecurities = get(),
             getStockQuote = get(),
             addHolding = get(),

--- a/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/MainNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/MainNavigation.kt
@@ -107,7 +107,7 @@ fun NavGraphBuilder.mainGraphNode(rootNavController: NavController) {
             floatingActionButton = {
                 when (selectedTab) {
                     BottomTab.DASHBOARD -> {
-                        FloatingActionButton(onClick = { innerNavController.navigate(SearchRoute) }) {
+                        FloatingActionButton(onClick = { rootNavController.navigate(SearchRoute) }) {
                             Icon(
                                 imageVector = Icons.Default.Search,
                                 contentDescription = null,
@@ -142,7 +142,6 @@ fun NavGraphBuilder.mainGraphNode(rootNavController: NavController) {
                 )
                 dividendsScreenNode(navController = innerNavController, rootNavController = rootNavController)
                 favoritesScreenNode(navController = innerNavController, rootNavController = rootNavController)
-                searchScreenNode(navController = innerNavController, rootNavController = rootNavController)
                 settingsScreenNode()
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/MainNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/MainNavigation.kt
@@ -73,14 +73,10 @@ fun NavGraphBuilder.mainGraphNode(rootNavController: NavController) {
         val selectedTab = when {
             currentRoute?.contains(DashboardRoute::class.simpleName ?: "") == true -> BottomTab.DASHBOARD
             currentRoute?.contains(PortfolioRoute::class.simpleName ?: "") == true -> BottomTab.PORTFOLIO
-            currentRoute?.contains(AddHoldingRoute::class.simpleName ?: "") == true -> BottomTab.PORTFOLIO
-            currentRoute?.contains(EditHoldingRoute::class.simpleName ?: "") == true -> BottomTab.PORTFOLIO
             currentRoute?.contains(DividendsRoute::class.simpleName ?: "") == true -> BottomTab.DIVIDENDS
             currentRoute?.contains(SettingsRoute::class.simpleName ?: "") == true -> BottomTab.SETTINGS
             else -> BottomTab.DASHBOARD
         }
-        val isHoldingRoute = currentRoute?.contains(AddHoldingRoute::class.simpleName ?: "") == true ||
-            currentRoute?.contains(EditHoldingRoute::class.simpleName ?: "") == true
 
         Scaffold(
             contentWindowInsets = WindowInsets(0),
@@ -115,13 +111,11 @@ fun NavGraphBuilder.mainGraphNode(rootNavController: NavController) {
                         }
                     }
                     BottomTab.PORTFOLIO -> {
-                        if (!isHoldingRoute) {
-                            FloatingActionButton(onClick = portfolioFabClick) {
-                                Icon(
-                                    imageVector = Icons.Default.Add,
-                                    contentDescription = stringResource(Res.string.portfolio_add_holding),
-                                )
-                            }
+                        FloatingActionButton(onClick = portfolioFabClick) {
+                            Icon(
+                                imageVector = Icons.Default.Add,
+                                contentDescription = stringResource(Res.string.portfolio_add_holding),
+                            )
                         }
                     }
                     else -> {}

--- a/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/MainNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/MainNavigation.kt
@@ -48,7 +48,7 @@ data object MainGraphRoute
 data object PortfolioRoute
 
 @Serializable
-data object AddHoldingRoute
+data class AddHoldingRoute(val ticker: String? = null)
 
 @Serializable
 data class EditHoldingRoute(val holdingId: String)

--- a/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/PortfolioNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/PortfolioNavigation.kt
@@ -52,16 +52,14 @@ fun NavGraphBuilder.portfolioScreenNode(
                     is PortfolioSideEffect.Navigation.NavigateToSecurity ->
                         rootNavController.navigateToSecurityDetail(ticker = navigation.ticker)
                     is PortfolioSideEffect.Navigation.NavigateToAddHolding ->
-                        navController.navigateToAddHolding()
+                        rootNavController.navigateToAddHolding()
                     is PortfolioSideEffect.Navigation.NavigateToEditHolding ->
-                        navController.navigateToEditHolding(navigation.holdingId)
+                        rootNavController.navigateToEditHolding(navigation.holdingId)
                 }
             },
         )
     }
 
-    addHoldingScreenNode(navController)
-    editHoldingScreenNode(navController)
 }
 
 fun NavGraphBuilder.addHoldingScreenNode(navController: NavController) {

--- a/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/PortfolioNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/PortfolioNavigation.kt
@@ -60,6 +60,11 @@ fun NavGraphBuilder.portfolioScreenNode(
         )
     }
 
+    addHoldingScreenNode(navController)
+    editHoldingScreenNode(navController)
+}
+
+fun NavGraphBuilder.addHoldingScreenNode(navController: NavController) {
     composable<AddHoldingRoute>(
         enterTransition = { slideInHorizontally { it } },
         popExitTransition = { slideOutHorizontally { it } },
@@ -75,7 +80,9 @@ fun NavGraphBuilder.portfolioScreenNode(
             onPositionDeleted = { navController.popBackStack() },
         )
     }
+}
 
+fun NavGraphBuilder.editHoldingScreenNode(navController: NavController) {
     composable<EditHoldingRoute>(
         enterTransition = { slideInHorizontally { it } },
         popExitTransition = { slideOutHorizontally { it } },

--- a/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/PortfolioNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/PortfolioNavigation.kt
@@ -22,8 +22,8 @@ fun NavController.navigateToPortfolio(navOptions: NavOptions? = null) {
     this.navigate(PortfolioRoute, navOptions)
 }
 
-fun NavController.navigateToAddHolding() {
-    this.navigate(AddHoldingRoute)
+fun NavController.navigateToAddHolding(ticker: String? = null) {
+    this.navigate(AddHoldingRoute(ticker))
 }
 
 fun NavController.navigateToEditHolding(holdingId: String) {
@@ -66,9 +66,10 @@ fun NavGraphBuilder.addHoldingScreenNode(navController: NavController) {
     composable<AddHoldingRoute>(
         enterTransition = { slideInHorizontally { it } },
         popExitTransition = { slideOutHorizontally { it } },
-    ) {
+    ) { backStackEntry ->
+        val route = backStackEntry.toRoute<AddHoldingRoute>()
         val viewModel = koinViewModel<HoldingViewModel>(
-            parameters = { parametersOf(null) }
+            parameters = { parametersOf(null, route.ticker) }
         )
 
         HoldingScreen(

--- a/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/RootNavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/RootNavGraph.kt
@@ -63,5 +63,7 @@ fun SetupRootNavGraph(navController: NavHostController) {
         mainGraphNode(navController)
         detailScreenNode(navController)
         securityDetailScreenNode(navController)
+        addHoldingScreenNode(navController)
+        editHoldingScreenNode(navController)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/RootNavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/RootNavGraph.kt
@@ -63,6 +63,7 @@ fun SetupRootNavGraph(navController: NavHostController) {
         mainGraphNode(navController)
         detailScreenNode(navController)
         securityDetailScreenNode(navController)
+        searchScreenNode(navController = navController, rootNavController = navController)
         addHoldingScreenNode(navController)
         editHoldingScreenNode(navController)
     }

--- a/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/SecurityDetailNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/SecurityDetailNavigation.kt
@@ -37,9 +37,8 @@ fun NavGraphBuilder.securityDetailScreenNode(navController: NavController) {
                 when (navigation) {
                     SecurityDetailSideEffect.Navigation.NavigateBack ->
                         navController.popBackStack()
-                    is SecurityDetailSideEffect.Navigation.NavigateToAddSecurity -> {
-                        navController.navigate(AddHoldingRoute)
-                    }
+                    is SecurityDetailSideEffect.Navigation.NavigateToAddSecurity ->
+                        navController.navigateToAddHolding(ticker = navigation.ticker)
                     is SecurityDetailSideEffect.Navigation.NavigateToEditHolding ->
                         navController.navigateToEditHolding(navigation.holdingId.value)
                 }

--- a/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/SecurityDetailNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/akole/dividox/navigation/SecurityDetailNavigation.kt
@@ -40,9 +40,8 @@ fun NavGraphBuilder.securityDetailScreenNode(navController: NavController) {
                     is SecurityDetailSideEffect.Navigation.NavigateToAddSecurity -> {
                         navController.navigate(AddHoldingRoute)
                     }
-                    is SecurityDetailSideEffect.Navigation.NavigateToEditHolding -> {
-                        // TK-025
-                    }
+                    is SecurityDetailSideEffect.Navigation.NavigateToEditHolding ->
+                        navController.navigateToEditHolding(navigation.holdingId.value)
                 }
             },
         )

--- a/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/PriceChartUtils.kt
+++ b/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/PriceChartUtils.kt
@@ -54,9 +54,18 @@ private fun PricePoint.toChartLabel(period: ChartPeriod): String {
 
 private fun List<PricePoint>.thinForPeriod(period: ChartPeriod): List<PricePoint> {
     return when (period) {
-        // ONE_YEAR uses weekly data with monthly labels — deduplicate to one point per month
-        // so the library's chartData size matches entries.size (no label collision in the map).
-        ChartPeriod.ONE_YEAR, ChartPeriod.YTD -> groupBy {
+        // ONE_YEAR uses weekly data spanning 2 calendar years (e.g. Jun 2024 – May 2025).
+        // Grouping by month produces 13 groups where the boundary month name appears twice
+        // (e.g. "May" for both 2024 and 2025). Taking the last 12 guarantees 12 consecutive
+        // months with no duplicate short-name labels, so the library's chartData map size
+        // matches entries.size and the scrubber overlay stays aligned.
+        ChartPeriod.ONE_YEAR -> groupBy {
+            val dt = it.timestamp.toLocalDateTime(TimeZone.UTC)
+            "${dt.year}-${(dt.month.ordinal + 1).toString().padStart(2, '0')}"
+        }.entries.sortedBy { it.key }.takeLast(12).mapNotNull { it.value.lastOrNull() }
+
+        // YTD spans only the current calendar year — months are always unique within a year.
+        ChartPeriod.YTD -> groupBy {
             val dt = it.timestamp.toLocalDateTime(TimeZone.UTC)
             "${dt.year}-${(dt.month.ordinal + 1).toString().padStart(2, '0')}"
         }.entries.sortedBy { it.key }.mapNotNull { it.value.lastOrNull() }

--- a/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/PriceChartUtils.kt
+++ b/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/PriceChartUtils.kt
@@ -26,7 +26,7 @@ internal fun List<PricePoint>.toPriceChartData(period: ChartPeriod): PriceChartD
         val label = when {
             period == ChartPeriod.ONE_DAY && dt.minute != 0 ->
                 "​".repeat(index + 1)
-            period == ChartPeriod.ONE_MONTH && dt.dayOfMonth % 5 != 0 ->
+            period == ChartPeriod.ONE_MONTH && dt.day % 5 != 0 ->
                 "​".repeat(index + 1)
             sparseLabel && reverseIndex % 2 != 0 ->
                 "​".repeat(index + 1)
@@ -45,7 +45,7 @@ private fun PricePoint.toChartLabel(period: ChartPeriod): String {
     val dt = timestamp.toLocalDateTime(TimeZone.UTC)
     return when (period) {
         ChartPeriod.ONE_DAY -> "${dt.hour}:${dt.minute.toString().padStart(2, '0')}"
-        ChartPeriod.ONE_WEEK, ChartPeriod.ONE_MONTH -> "${dt.dayOfMonth} ${dt.date.monthShort()}"
+        ChartPeriod.ONE_WEEK, ChartPeriod.ONE_MONTH -> "${dt.day} ${dt.date.monthShort()}"
         ChartPeriod.YTD, ChartPeriod.ONE_YEAR -> dt.date.monthShort()
         ChartPeriod.FIVE_YEARS -> dt.date.monthShortWithYear()
         ChartPeriod.ALL -> dt.year.toString()
@@ -54,9 +54,22 @@ private fun PricePoint.toChartLabel(period: ChartPeriod): String {
 
 private fun List<PricePoint>.thinForPeriod(period: ChartPeriod): List<PricePoint> {
     return when (period) {
+        // ONE_YEAR uses weekly data with monthly labels — deduplicate to one point per month
+        // so the library's chartData size matches entries.size (no label collision in the map).
+        ChartPeriod.ONE_YEAR, ChartPeriod.YTD -> groupBy {
+            val dt = it.timestamp.toLocalDateTime(TimeZone.UTC)
+            "${dt.year}-${(dt.month.ordinal + 1).toString().padStart(2, '0')}"
+        }.entries.sortedBy { it.key }.mapNotNull { it.value.lastOrNull() }
+
+        // ONE_WEEK uses hourly data with daily labels — deduplicate to one point per day.
+        ChartPeriod.ONE_WEEK -> groupBy {
+            val dt = it.timestamp.toLocalDateTime(TimeZone.UTC)
+            "${dt.year}-${(dt.month.ordinal + 1).toString().padStart(2, '0')}-${dt.day.toString().padStart(2, '0')}"
+        }.entries.sortedBy { it.key }.mapNotNull { it.value.lastOrNull() }
+
         ChartPeriod.FIVE_YEARS -> groupBy {
             val dt = it.timestamp.toLocalDateTime(TimeZone.UTC)
-            "${dt.year}-Q${(dt.monthNumber - 1) / 3}"
+            "${dt.year}-Q${dt.month.ordinal / 3}"
         }.entries.sortedBy { it.key }.mapNotNull { it.value.lastOrNull() }
 
         ChartPeriod.ALL -> {

--- a/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/SecurityDetailContract.kt
+++ b/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/SecurityDetailContract.kt
@@ -9,6 +9,7 @@ import com.akole.dividox.component.market.domain.model.CompanyInfo
 import com.akole.dividox.component.market.domain.model.DividendInfo
 import com.akole.dividox.component.market.domain.model.PricePoint
 import com.akole.dividox.component.market.domain.model.StockQuote
+import com.akole.dividox.component.portfolio.domain.model.HoldingId
 import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 
@@ -30,6 +31,7 @@ interface SecurityDetailContract {
         val isDividendChartPercentage: Boolean = false,
         val dividendGrowthData: List<DividendGrowthBar> = emptyList(),
         val isInPortfolio: Boolean = false,
+        val holdingId: HoldingId? = null,
         val error: String? = null,
     ) : ViewState
 
@@ -47,13 +49,14 @@ interface SecurityDetailContract {
         data class ChartPeriodSelected(val period: ChartPeriod) : SecurityDetailViewEvent
         data object ToggleDividendChartMode : SecurityDetailViewEvent
         data object OnAddSecurityClicked : SecurityDetailViewEvent
+        data object OnEditHoldingClicked : SecurityDetailViewEvent
     }
 
     sealed interface SecurityDetailSideEffect : SideEffect {
         sealed interface Navigation : SecurityDetailSideEffect {
             data object NavigateBack : Navigation
             data class NavigateToAddSecurity(val ticker: String) : Navigation
-            data class NavigateToEditHolding(val ticker: String) : Navigation
+            data class NavigateToEditHolding(val holdingId: HoldingId) : Navigation
         }
 
         sealed interface Message : SecurityDetailSideEffect {

--- a/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/SecurityDetailScreen.kt
+++ b/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/SecurityDetailScreen.kt
@@ -90,6 +90,7 @@ import org.jetbrains.compose.resources.stringResource
 private val PriceChartHeight = 200.dp
 private val DividendChartHeight = 250.dp
 
+@Suppress("LongMethod")
 @Composable
 fun SecurityDetailScreen(
     state: SecurityDetailViewState,
@@ -452,19 +453,28 @@ private fun DividendGrowthSection(
                     fontWeight = FontWeight.SemiBold,
                 )
                 Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xSmall)) {
-                    listOf(false to quoteCurrency.symbol, true to stringResource(Res.string.analysis_view_as_percent)).forEach { (isPercent, label) ->
+                    listOf(
+                        false to quoteCurrency.symbol,
+                        true to stringResource(Res.string.analysis_view_as_percent)).forEach { (isPercent, label) ->
                         val isSelected = state.isDividendChartPercentage == isPercent
                         Surface(
                             shape = RoundedCornerShape(6.dp),
-                            color = if (isSelected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainerHigh,
-                            modifier = Modifier.clickable { if (!isSelected) onEvent(SecurityDetailViewEvent.ToggleDividendChartMode) },
+                            color = if (isSelected) MaterialTheme.colorScheme.primaryContainer
+                            else MaterialTheme.colorScheme.surfaceContainerHigh,
+                            modifier = Modifier.clickable {
+                                if (!isSelected) onEvent(SecurityDetailViewEvent.ToggleDividendChartMode)
+                                                          },
                         ) {
                             Text(
                                 text = label,
                                 style = MaterialTheme.typography.labelSmall,
                                 fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-                                color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
-                                modifier = Modifier.padding(horizontal = MaterialTheme.spacing.small, vertical = MaterialTheme.spacing.xSmall),
+                                color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer
+                                else MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.padding(
+                                    horizontal = MaterialTheme.spacing.small,
+                                    vertical = MaterialTheme.spacing.xSmall,
+                                ),
                             )
                         }
                     }
@@ -565,12 +575,12 @@ private fun FundamentalsSection(state: SecurityDetailViewState) {
             ) {
                 MetricCard(
                     label = stringResource(Res.string.metric_ex_dividend_date),
-                    value = dividendInfo?.exDividendDate?.toString() ?: "N/A",
+                    value = dividendInfo.exDividendDate?.toString() ?: "N/A",
                     modifier = Modifier.weight(1f).fillMaxHeight(),
                 )
                 MetricCard(
                     label = stringResource(Res.string.metric_next_dividend_date),
-                    value = dividendInfo?.nextDividendDate?.toString() ?: "N/A",
+                    value = dividendInfo.nextDividendDate?.toString() ?: "N/A",
                     modifier = Modifier.weight(1f).fillMaxHeight(),
                 )
             }

--- a/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/SecurityDetailScreen.kt
+++ b/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/SecurityDetailScreen.kt
@@ -581,7 +581,10 @@ private fun CtaButton(
     onEvent: (SecurityDetailViewEvent) -> Unit,
 ) {
     Button(
-        onClick = { onEvent(SecurityDetailViewEvent.OnAddSecurityClicked) },
+        onClick = {
+            if (state.isInPortfolio) onEvent(SecurityDetailViewEvent.OnEditHoldingClicked)
+            else onEvent(SecurityDetailViewEvent.OnAddSecurityClicked)
+        },
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = MaterialTheme.spacing.medium)

--- a/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/SecurityDetailScreen.kt
+++ b/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/SecurityDetailScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.akole.dividox.common.currency.domain.model.Currency
 import com.akole.dividox.common.mvi.CollectSideEffect
 import com.akole.dividox.common.ui.resources.charts.BarChart
 import com.akole.dividox.common.ui.resources.charts.BarChartEntry
@@ -220,7 +221,7 @@ private fun PriceCard(state: SecurityDetailViewState) {
                 verticalAlignment = Alignment.Bottom,
             ) {
                 Text(
-                    text = quote.price.formatPrice(state.currency),
+                    text = quote.price.formatPrice(quote.currency),
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold,
                 )
@@ -328,7 +329,7 @@ private fun ChartSection(
                     height = PriceChartHeight,
                     yAxisValueOffset = floorPrice,
                     popupFormatter = { label, value ->
-                        val formattedValue = (value + floorPrice).toDouble().formatPrice(state.currency.code)
+                        val formattedValue = (value + floorPrice).toDouble().formatPrice(state.quote?.currency ?: "USD")
                         "$formattedValue · $label"
                     },
                 )
@@ -347,6 +348,7 @@ private fun ChartSection(
 @Composable
 private fun DividendMetricsSection(state: SecurityDetailViewState) {
     val dividendInfo = state.dividendInfo ?: return
+    val quoteCurrencyCode = state.quote?.currency ?: "USD"
 
     Column(
         modifier = Modifier
@@ -371,7 +373,7 @@ private fun DividendMetricsSection(state: SecurityDetailViewState) {
             )
             MetricCard(
                 label = stringResource(Res.string.analysis_metric_annual_payout),
-                value = dividendInfo.annualPayout.formatTwoDecimals(),
+                value = dividendInfo.annualPayout.formatPrice(quoteCurrencyCode),
                 modifier = Modifier.weight(1f).fillMaxHeight(),
             )
         }
@@ -431,6 +433,7 @@ private fun DividendGrowthSection(
     state: SecurityDetailViewState,
     onEvent: (SecurityDetailViewEvent) -> Unit,
 ) {
+    val quoteCurrency = Currency.entries.firstOrNull { it.code == (state.quote?.currency ?: "USD") } ?: Currency.USD
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -449,7 +452,7 @@ private fun DividendGrowthSection(
                     fontWeight = FontWeight.SemiBold,
                 )
                 Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xSmall)) {
-                    listOf(false to state.currency.symbol, true to stringResource(Res.string.analysis_view_as_percent)).forEach { (isPercent, label) ->
+                    listOf(false to quoteCurrency.symbol, true to stringResource(Res.string.analysis_view_as_percent)).forEach { (isPercent, label) ->
                         val isSelected = state.isDividendChartPercentage == isPercent
                         Surface(
                             shape = RoundedCornerShape(6.dp),
@@ -490,7 +493,7 @@ private fun DividendGrowthSection(
                     if (state.isDividendChartPercentage) {
                         "${entry.value.toDouble().formatTwoDecimals()}%"
                     } else {
-                        formatBarChartPopupLabel(entry.value, state.currency.code, entry.label)
+                        formatBarChartPopupLabel(entry.value, quoteCurrency.code, entry.label)
                     }
                 },
             )
@@ -522,12 +525,12 @@ private fun FundamentalsSection(state: SecurityDetailViewState) {
         ) {
             MetricCard(
                 label = stringResource(Res.string.metric_52w_high),
-                value = quote.fiftyTwoWeekHigh?.formatPrice(state.currency) ?: "N/A",
+                value = quote.fiftyTwoWeekHigh?.formatPrice(quote.currency) ?: "N/A",
                 modifier = Modifier.weight(1f).fillMaxHeight(),
             )
             MetricCard(
                 label = stringResource(Res.string.metric_52w_low),
-                value = quote.fiftyTwoWeekLow?.formatPrice(state.currency) ?: "N/A",
+                value = quote.fiftyTwoWeekLow?.formatPrice(quote.currency) ?: "N/A",
                 modifier = Modifier.weight(1f).fillMaxHeight(),
             )
         }
@@ -539,7 +542,7 @@ private fun FundamentalsSection(state: SecurityDetailViewState) {
             horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small),
         ) {
             val dayRange = if (quote.dayLow != null && quote.dayHigh != null) {
-                "${quote.dayLow!!.formatPrice(state.currency)} – ${quote.dayHigh!!.formatPrice(state.currency)}"
+                "${quote.dayLow!!.formatPrice(quote.currency)} – ${quote.dayHigh!!.formatPrice(quote.currency)}"
             } else "N/A"
             MetricCard(
                 label = stringResource(Res.string.metric_day_range),

--- a/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/SecurityDetailViewModel.kt
+++ b/feature/analysis/src/commonMain/kotlin/com/akole/dividox/feature/analysis/SecurityDetailViewModel.kt
@@ -63,6 +63,7 @@ class SecurityDetailViewModel(
             is SecurityDetailViewEvent.ChartPeriodSelected -> selectChartPeriod(viewEvent.period)
             SecurityDetailViewEvent.ToggleDividendChartMode -> toggleDividendChartMode()
             SecurityDetailViewEvent.OnAddSecurityClicked -> navigateToAddSecurity()
+            SecurityDetailViewEvent.OnEditHoldingClicked -> navigateToEditHolding()
         }
     }
 
@@ -114,6 +115,7 @@ class SecurityDetailViewModel(
                             priceHistory = detail.priceHistory,
                             renderedChartPeriod = period,
                             isInPortfolio = detail.isInPortfolio,
+                            holdingId = detail.holdingId,
                             lastUpdated = Clock.System.now(),
                             isLoading = false,
                         )
@@ -183,6 +185,13 @@ class SecurityDetailViewModel(
     private fun navigateToAddSecurity() {
         viewModelScope.emitSideEffect(
             SecurityDetailSideEffect.Navigation.NavigateToAddSecurity(ticker)
+        )
+    }
+
+    private fun navigateToEditHolding() {
+        val holdingId = viewState.value.holdingId ?: return
+        viewModelScope.emitSideEffect(
+            SecurityDetailSideEffect.Navigation.NavigateToEditHolding(holdingId)
         )
     }
 }

--- a/feature/analysis/src/commonTest/kotlin/com/akole/dividox/feature/analysis/SecurityDetailViewModelTest.kt
+++ b/feature/analysis/src/commonTest/kotlin/com/akole/dividox/feature/analysis/SecurityDetailViewModelTest.kt
@@ -7,32 +7,57 @@ import com.akole.dividox.common.settings.AppRefreshTracker
 import com.akole.dividox.common.settings.domain.model.AppSettings
 import com.akole.dividox.common.settings.domain.usecase.ObserveAppSettingsUseCase
 import com.akole.dividox.component.market.domain.model.ChartPeriod
-import com.akole.dividox.component.market.domain.model.StockQuote
 import com.akole.dividox.component.market.domain.model.PricePoint
+import com.akole.dividox.component.market.domain.model.StockQuote
+import com.akole.dividox.component.market.domain.usecase.GetHistoricalDividendEventsUseCase
+import com.akole.dividox.component.market.domain.usecase.GetPriceHistoryUseCase
 import com.akole.dividox.component.market.domain.usecase.GetStockQuoteUseCase
+import com.akole.dividox.component.portfolio.domain.model.HoldingId
 import com.akole.dividox.component.watchlist.domain.usecase.AddToWatchlistUseCase
 import com.akole.dividox.component.watchlist.domain.usecase.IsInWatchlistUseCase
 import com.akole.dividox.component.watchlist.domain.usecase.RemoveFromWatchlistUseCase
-import com.akole.dividox.feature.analysis.SecurityDetailContract.SecurityDetailViewEvent
 import com.akole.dividox.feature.analysis.SecurityDetailContract.SecurityDetailSideEffect
+import com.akole.dividox.feature.analysis.SecurityDetailContract.SecurityDetailViewEvent
 import com.akole.dividox.integration.security.domain.model.SecurityDetail
 import com.akole.dividox.integration.security.domain.usecase.GetSecurityDetailUseCase
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
-import kotlin.time.Clock
-import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runTest
+import io.mockk.Runs
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class SecurityDetailViewModelTest {
 
+    private val testScheduler = TestCoroutineScheduler()
+    private val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+
     private val ticker = "AAPL"
+
     private val mockGetSecurityDetail = mockk<GetSecurityDetailUseCase>()
     private val mockGetStockQuote = mockk<GetStockQuoteUseCase>()
+    private val mockGetHistoricalDividendEvents = mockk<GetHistoricalDividendEventsUseCase>()
+    private val mockGetPriceHistory = mockk<GetPriceHistoryUseCase>()
     private val mockIsInWatchlist = mockk<IsInWatchlistUseCase>()
     private val mockAddToWatchlist = mockk<AddToWatchlistUseCase>()
     private val mockRemoveFromWatchlist = mockk<RemoveFromWatchlistUseCase>()
@@ -41,164 +66,202 @@ class SecurityDetailViewModelTest {
     private val mockCurrencyConverter = mockk<CurrencyConverter>()
     private val mockRefreshTracker = mockk<AppRefreshTracker>()
 
-    private fun createViewModel(): SecurityDetailViewModel {
-        // Setup default mock behaviors
-        every { mockObserveAppSettings() } returns flowOf(
-            AppSettings(currency = Currency.USD)
-        )
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        every { mockObserveAppSettings() } returns flowOf(AppSettings(currency = Currency.USD))
         every { mockIsInWatchlist(any()) } returns flowOf(false)
-        coEvery { mockGetStockQuote(any()).getOrNull() } returns null
-        every { mockConnectivityManager.isConnected } returns flowOf(true)
-
-        return SecurityDetailViewModel(
-            ticker = ticker,
-            getSecurityDetail = mockGetSecurityDetail,
-            getStockQuote = mockGetStockQuote,
-            isInWatchlist = mockIsInWatchlist,
-            addToWatchlist = mockAddToWatchlist,
-            removeFromWatchlist = mockRemoveFromWatchlist,
-            connectivityManager = mockConnectivityManager,
-            observeAppSettings = mockObserveAppSettings,
-            currencyConverter = mockCurrencyConverter,
-            refreshTracker = mockRefreshTracker,
-        )
+        every { mockConnectivityManager.observeConnectivity() } returns emptyFlow()
+        every { mockGetSecurityDetail(any(), any()) } returns emptyFlow()
+        every { mockGetPriceHistory(any(), any()) } returns flowOf(emptyList())
+        coEvery { mockGetHistoricalDividendEvents(any(), any()) } returns Result.success(emptyList())
+        coEvery { mockAddToWatchlist(any()) } just Runs
+        coEvery { mockRemoveFromWatchlist(any()) } just Runs
     }
 
-    @Test
-    fun `SHOULD load security details on OnLoad GIVEN initial state`() = runTest {
-        // GIVEN
-        val quote = StockQuote(
-            ticker = ticker,
-            price = 150.0,
-            change = 2.5,
-            changePercent = 1.69,
-            currency = "USD",
-            lastUpdated = Clock.System.now(),
-        )
-        val priceHistory = listOf(
-            PricePoint(Clock.System.now(), 150.0),
-            PricePoint(Clock.System.now(), 149.5),
-        )
-        val securityDetail = SecurityDetail(
-            ticker = ticker,
-            quote = quote,
-            dividendInfo = null,
-            companyInfo = null,
-            priceHistory = priceHistory,
-            isInPortfolio = false,
-            isInWatchlist = false,
-            holdingId = null,
-        )
+    @AfterTest
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
 
-        every { mockGetSecurityDetail(ticker, ChartPeriod.ONE_YEAR) } returns flowOf(
-            securityDetail
-        )
+    private fun viewModel() = SecurityDetailViewModel(
+        ticker = ticker,
+        getSecurityDetail = mockGetSecurityDetail,
+        getStockQuote = mockGetStockQuote,
+        getHistoricalDividendEvents = mockGetHistoricalDividendEvents,
+        getPriceHistory = mockGetPriceHistory,
+        isInWatchlist = mockIsInWatchlist,
+        addToWatchlist = mockAddToWatchlist,
+        removeFromWatchlist = mockRemoveFromWatchlist,
+        connectivityManager = mockConnectivityManager,
+        observeAppSettings = mockObserveAppSettings,
+        currencyConverter = mockCurrencyConverter,
+        refreshTracker = mockRefreshTracker,
+    )
+
+    // ─── Load ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `SHOULD populate state WHEN security detail emits GIVEN OnLoad`() = runTest(testScheduler) {
+        // GIVEN
+        val detail = aSecurityDetail()
+        every { mockGetSecurityDetail(ticker, ChartPeriod.ONE_YEAR) } returns flowOf(detail)
+        val vm = viewModel()
 
         // WHEN
-        val viewModel = createViewModel()
-        viewModel.onViewEvent(SecurityDetailViewEvent.OnLoad)
+        vm.onViewEvent(SecurityDetailViewEvent.OnLoad)
+        advanceUntilIdle()
 
         // THEN
-        val state = viewModel.viewState.value
-        assertEquals(ticker, state.ticker)
-        assertEquals(quote.price, state.quote?.price)
-        assertEquals(priceHistory.size, state.priceHistory.size)
+        assertEquals(ticker, vm.viewState.value.ticker)
+        assertEquals(detail.quote.price, vm.viewState.value.quote?.price)
     }
 
-    @Test
-    fun `SHOULD toggle favorite status WHEN OnFavoriteToggled GIVEN not in watchlist`() = runTest {
-        // GIVEN
-        val quote = StockQuote(
-            ticker = ticker,
-            price = 150.0,
-            change = 2.5,
-            changePercent = 1.69,
-            currency = "USD",
-            lastUpdated = Clock.System.now(),
-        )
-        every { mockGetSecurityDetail(ticker, any()) } returns flowOf(
-            SecurityDetail(
-                ticker = ticker,
-                quote = quote,
-                dividendInfo = null,
-                companyInfo = null,
-                priceHistory = emptyList(),
-                isInPortfolio = false,
-                isInWatchlist = false,
-                holdingId = null,
-            )
-        )
-        coEvery { mockAddToWatchlist(ticker) } returns Result.success(Unit)
+    // ─── Watchlist ────────────────────────────────────────────────────────────
 
-        val viewModel = createViewModel()
-        viewModel.onViewEvent(SecurityDetailViewEvent.OnLoad)
+    @Test
+    fun `SHOULD call addToWatchlist WHEN OnFavoriteToggled GIVEN not in watchlist`() = runTest(testScheduler) {
+        // GIVEN
+        every { mockIsInWatchlist(any()) } returns flowOf(false)
+        val vm = viewModel()
+        advanceUntilIdle()
 
         // WHEN
-        viewModel.onViewEvent(SecurityDetailViewEvent.OnFavoriteToggled)
+        vm.onViewEvent(SecurityDetailViewEvent.OnFavoriteToggled)
+        advanceUntilIdle()
 
         // THEN
         coVerify { mockAddToWatchlist(ticker) }
     }
 
+    // ─── Chart period ─────────────────────────────────────────────────────────
+
     @Test
-    fun `SHOULD change chart period WHEN ChartPeriodSelected GIVEN valid period`() = runTest {
+    fun `SHOULD update selectedChartPeriod WHEN ChartPeriodSelected GIVEN new period`() = runTest(testScheduler) {
         // GIVEN
-        every { mockGetSecurityDetail(ticker, ChartPeriod.ONE_WEEK) } returns flowOf(
-            SecurityDetail(
-                ticker = ticker,
-                quote = StockQuote(
-                    ticker = ticker,
-                    price = 150.0,
-                    change = 0.5,
-                    changePercent = 0.33,
-                    currency = "USD",
-                    lastUpdated = Clock.System.now(),
-                ),
-                dividendInfo = null,
-                companyInfo = null,
-                priceHistory = emptyList(),
-                isInPortfolio = false,
-                isInWatchlist = false,
-                holdingId = null,
-            )
+        every { mockGetSecurityDetail(ticker, ChartPeriod.ONE_WEEK) } returns emptyFlow()
+        val vm = viewModel()
+
+        // WHEN
+        vm.onViewEvent(SecurityDetailViewEvent.ChartPeriodSelected(ChartPeriod.ONE_WEEK))
+        advanceUntilIdle()
+
+        // THEN
+        assertEquals(ChartPeriod.ONE_WEEK, vm.viewState.value.selectedChartPeriod)
+    }
+
+    // ─── Dividend chart toggle ────────────────────────────────────────────────
+
+    @Test
+    fun `SHOULD toggle isDividendChartPercentage WHEN ToggleDividendChartMode`() = runTest(testScheduler) {
+        // GIVEN
+        val vm = viewModel()
+        val initial = vm.viewState.value.isDividendChartPercentage
+
+        // WHEN
+        vm.onViewEvent(SecurityDetailViewEvent.ToggleDividendChartMode)
+
+        // THEN
+        assertEquals(!initial, vm.viewState.value.isDividendChartPercentage)
+    }
+
+    // ─── Navigation ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `SHOULD emit NavigateBack WHEN OnBackClicked`() = runTest(testScheduler) {
+        // GIVEN
+        val vm = viewModel()
+        val effects = mutableListOf<SecurityDetailSideEffect>()
+        val job = launch { vm.sideEffect.collect(effects::add) }
+
+        // WHEN
+        vm.onViewEvent(SecurityDetailViewEvent.OnBackClicked)
+        advanceUntilIdle()
+        job.cancel()
+
+        // THEN
+        assertIs<SecurityDetailSideEffect.Navigation.NavigateBack>(effects.first())
+    }
+
+    @Test
+    fun `SHOULD emit NavigateToEditHolding WHEN OnEditHoldingClicked GIVEN ticker in portfolio`() = runTest(testScheduler) {
+        // GIVEN
+        val holdingId = HoldingId("holding-1")
+        every { mockGetSecurityDetail(any(), any()) } returns flowOf(
+            aSecurityDetail(isInPortfolio = true, holdingId = holdingId)
         )
-
-        val viewModel = createViewModel()
+        val vm = viewModel()
+        advanceUntilIdle()
+        val effects = mutableListOf<SecurityDetailSideEffect>()
+        val job = launch { vm.sideEffect.collect(effects::add) }
 
         // WHEN
-        viewModel.onViewEvent(SecurityDetailViewEvent.ChartPeriodSelected(ChartPeriod.ONE_WEEK))
+        vm.onViewEvent(SecurityDetailViewEvent.OnEditHoldingClicked)
+        advanceUntilIdle()
+        job.cancel()
 
         // THEN
-        val state = viewModel.viewState.value
-        assertEquals(ChartPeriod.ONE_WEEK, state.selectedChartPeriod)
+        val effect = assertIs<SecurityDetailSideEffect.Navigation.NavigateToEditHolding>(effects.first())
+        assertEquals(holdingId, effect.holdingId)
     }
 
     @Test
-    fun `SHOULD toggle dividend chart mode WHEN ToggleDividendChartMode GIVEN current state`() = runTest {
+    fun `SHOULD emit NavigateToAddSecurity WHEN OnAddSecurityClicked GIVEN ticker not in portfolio`() = runTest(testScheduler) {
         // GIVEN
-        every { mockGetSecurityDetail(ticker, any()) } returns emptyFlow()
-        val viewModel = createViewModel()
-        val initialMode = viewModel.viewState.value.isDividendChartPercentage
+        val vm = viewModel()
+        val effects = mutableListOf<SecurityDetailSideEffect>()
+        val job = launch { vm.sideEffect.collect(effects::add) }
 
         // WHEN
-        viewModel.onViewEvent(SecurityDetailViewEvent.ToggleDividendChartMode)
+        vm.onViewEvent(SecurityDetailViewEvent.OnAddSecurityClicked)
+        advanceUntilIdle()
+        job.cancel()
 
         // THEN
-        val state = viewModel.viewState.value
-        assertEquals(!initialMode, state.isDividendChartPercentage)
+        val effect = assertIs<SecurityDetailSideEffect.Navigation.NavigateToAddSecurity>(effects.first())
+        assertEquals(ticker, effect.ticker)
     }
 
     @Test
-    fun `SHOULD emit navigation side effect WHEN OnBackClicked GIVEN in detail view`() = runTest {
+    fun `SHOULD NOT emit NavigateToEditHolding WHEN OnEditHoldingClicked GIVEN holdingId is null`() = runTest(testScheduler) {
         // GIVEN
-        every { mockGetSecurityDetail(ticker, any()) } returns emptyFlow()
-        val viewModel = createViewModel()
+        every { mockGetSecurityDetail(any(), any()) } returns flowOf(
+            aSecurityDetail(isInPortfolio = true, holdingId = null)
+        )
+        val vm = viewModel()
+        advanceUntilIdle()
+        val effects = mutableListOf<SecurityDetailSideEffect>()
+        val job = launch { vm.sideEffect.collect(effects::add) }
 
         // WHEN
-        viewModel.onViewEvent(SecurityDetailViewEvent.OnBackClicked)
+        vm.onViewEvent(SecurityDetailViewEvent.OnEditHoldingClicked)
+        advanceUntilIdle()
+        job.cancel()
 
         // THEN
-        val sideEffect = viewModel.sideEffect.value
-        assertEquals(SecurityDetailSideEffect.Navigation.NavigateBack, sideEffect)
+        assertTrue(effects.isEmpty())
     }
+
+    // ─── Test fixtures ────────────────────────────────────────────────────────
+
+    private fun aSecurityDetail(
+        isInPortfolio: Boolean = false,
+        holdingId: HoldingId? = null,
+    ) = SecurityDetail(
+        ticker = ticker,
+        quote = StockQuote(
+            ticker = ticker,
+            price = 150.0,
+            change = 0.0,
+            changePercent = 0.0,
+            currency = "USD",
+            lastUpdated = Instant.fromEpochMilliseconds(0),
+        ),
+        dividendInfo = null,
+        companyInfo = null,
+        priceHistory = emptyList(),
+        isInPortfolio = isInPortfolio,
+        isInWatchlist = false,
+        holdingId = holdingId,
+    )
 }

--- a/feature/dashboard/src/commonMain/kotlin/com/akole/dividox/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/commonMain/kotlin/com/akole/dividox/feature/dashboard/DashboardViewModel.kt
@@ -27,14 +27,18 @@ import com.akole.dividox.integration.security.domain.usecase.GetEnrichedWatchlis
 import com.akole.dividox.integration.security.domain.usecase.GetPortfolioPeriodGainUseCase
 import com.akole.dividox.integration.security.domain.usecase.GetPortfolioSummaryUseCase
 import com.akole.dividox.integration.security.domain.usecase.GetPortfolioWithQuotesUseCase
+import com.akole.dividox.integration.security.domain.model.PortfolioSummary
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlin.time.Clock
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -58,7 +62,8 @@ class DashboardViewModel(
     private var dataJob: Job? = null
     private val periodFlow = MutableStateFlow(ChartPeriod.ALL)
     // Internal flows updated by separate coroutines so slow API calls don't block main UI data
-    private val periodGainFlow = MutableStateFlow(0.0 to 0.0) // (absoluteUsd, percent)
+    private val summaryFlow = MutableStateFlow<PortfolioSummary?>(null)         // null until portfolio API calls complete
+    private val periodGainFlow = MutableStateFlow<Pair<Double, Double>?>(null)  // null until first gain result
     private val periodDividendsFlow = MutableStateFlow(0.0)   // USD, unconverted
     private val lifetimeDividendsFlow = MutableStateFlow(0.0) // USD, unconverted
 
@@ -102,6 +107,11 @@ class DashboardViewModel(
     private fun observeData() {
         dataJob?.cancel()
         dataJob = viewModelScope.launch {
+            // Single upstream shared between gain coroutine and summary — no double API calls.
+            val portfolioShared = getPortfolioWithQuotes()
+                .filter { it.isNotEmpty() }
+                .shareIn(this, SharingStarted.WhileSubscribed(), replay = 1)
+
             // 1. Period dividends — Room query, fast, restarts on period change
             launch {
                 periodFlow.flatMapLatest { period ->
@@ -118,9 +128,17 @@ class DashboardViewModel(
                 }
             }
 
-            // 2. Period gain — potentially slow API calls, cancelled on new emission (collectLatest)
+            // 2. Portfolio summary — slowest flow (requires all quote API calls to complete).
+            // Feeds summaryFlow; isLoading stays true until first emission.
             launch {
-                combine(getPortfolioWithQuotes(), periodFlow) { holdings, period ->
+                getPortfolioSummary(portfolioShared).collect { summary ->
+                    summaryFlow.value = summary
+                }
+            }
+
+            // 3. Period gain — cancelled and restarted on new portfolio or period emission.
+            launch {
+                combine(portfolioShared, periodFlow) { holdings, period ->
                     holdings to period
                 }.collectLatest { (holdings, period) ->
                     val (abs, pct) = getPortfolioPeriodGain(holdings, period.toMarketPeriod())
@@ -128,21 +146,24 @@ class DashboardViewModel(
                 }
             }
 
-            // 3. Main combine — period-independent data + derived period StateFlows, always fast
+            // 4. Main combine — skeleton stays until summaryFlow has its first real value.
             val dividendPairFlow =
                 combine(periodDividendsFlow, lifetimeDividendsFlow) { period, lifetime -> period to lifetime }
             combine(
-                getPortfolioSummary(),
+                summaryFlow,
                 getEnrichedWatchlist(),
                 observeAppSettings(),
                 dividendPairFlow,
                 periodGainFlow,
-            ) { summary, watchlist, settings, (dividends, lifetime), (gainAbs, gainPct) ->
+            ) { summary, watchlist, settings, dividendPair, gainPair ->
+                val (dividends, lifetime) = dividendPair
+                val gainAbs = gainPair?.first ?: 0.0
+                val gainPct = gainPair?.second ?: 0.0
                 val targetCurrency = settings.currency
-                val convertedSummary = currencyConverter.convertSummary(summary, targetCurrency)
+                val convertedSummary = summary?.let { currencyConverter.convertSummary(it, targetCurrency) }
                 val convertedWatchlistPrices = currencyConverter.convertWatchlistPrices(watchlist, targetCurrency)
                 viewState.value.copy(
-                    isLoading = false,
+                    isLoading = summary == null || gainPair == null || summary.totalValue == 0.0,
                     isRefreshing = false,
                     summary = convertedSummary,
                     watchlist = watchlist,

--- a/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingContract.kt
+++ b/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingContract.kt
@@ -1,6 +1,7 @@
 package com.akole.dividox.feature.portfolio
 
 import com.akole.dividox.common.currency.domain.model.Currency
+import com.akole.dividox.common.ui.resources.components.ExchangeMarket
 import com.akole.dividox.component.market.domain.model.StockQuote
 import com.akole.dividox.component.portfolio.domain.model.HoldingId
 import com.akole.dividox.component.portfolio.domain.model.Holding
@@ -23,6 +24,7 @@ object HoldingContract {
         val currency: Currency = Currency.USD,
         val purchaseDateMillis: Long = kotlin.time.Clock.System.now().toEpochMilliseconds(),
         val estimatedTotal: Double = 0.0,
+        val selectedMarket: ExchangeMarket = ExchangeMarket.ALL,
         val isSearching: Boolean = false,
         val isSaving: Boolean = false,
         val error: String? = null,
@@ -37,6 +39,7 @@ object HoldingContract {
 
         // Search & selection
         data class SearchQueryChanged(val query: String) : HoldingViewEvent
+        data class MarketFilterChanged(val market: ExchangeMarket) : HoldingViewEvent
         data class SecuritySelected(val security: StockQuote) : HoldingViewEvent
 
         // Form inputs

--- a/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingContract.kt
+++ b/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingContract.kt
@@ -2,6 +2,7 @@ package com.akole.dividox.feature.portfolio
 
 import com.akole.dividox.common.currency.domain.model.Currency
 import com.akole.dividox.common.ui.resources.components.ExchangeMarket
+import com.akole.dividox.component.market.domain.model.SecurityType
 import com.akole.dividox.component.market.domain.model.StockQuote
 import com.akole.dividox.component.portfolio.domain.model.HoldingId
 import com.akole.dividox.component.portfolio.domain.model.Holding
@@ -25,6 +26,7 @@ object HoldingContract {
         val purchaseDateMillis: Long = kotlin.time.Clock.System.now().toEpochMilliseconds(),
         val estimatedTotal: Double = 0.0,
         val selectedMarket: ExchangeMarket = ExchangeMarket.ALL,
+        val selectedType: SecurityType? = null,
         val isSearching: Boolean = false,
         val isSaving: Boolean = false,
         val error: String? = null,
@@ -40,6 +42,7 @@ object HoldingContract {
         // Search & selection
         data class SearchQueryChanged(val query: String) : HoldingViewEvent
         data class MarketFilterChanged(val market: ExchangeMarket) : HoldingViewEvent
+        data class TypeFilterChanged(val type: SecurityType?) : HoldingViewEvent
         data class SecuritySelected(val security: StockQuote) : HoldingViewEvent
 
         // Form inputs

--- a/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
+++ b/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.akole.dividox.common.currency.domain.model.Currency
 import com.akole.dividox.common.ui.resources.components.DividoxTopAppBar
+import com.akole.dividox.common.ui.resources.components.SearchBar
 import com.akole.dividox.common.ui.resources.components.connectivity.ConnectivityBannerHost
 import com.akole.dividox.common.ui.resources.components.connectivity.LocalNetworkConnectivityManager
 import com.akole.dividox.common.ui.resources.format.formatPrice
@@ -301,12 +302,11 @@ private fun SearchSecurityField(
     onSecuritySelected: (StockQuote) -> Unit,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)) {
-        OutlinedTextField(
-            value = query,
-            onValueChange = onQueryChanged,
-            label = { Text(stringResource(Res.string.holding_search_security_hint)) },
+        SearchBar(
+            query = query,
+            onQueryChange = onQueryChanged,
+            placeholder = stringResource(Res.string.holding_search_security_hint),
             modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
             enabled = selectedSecurity == null,
         )
 

--- a/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
+++ b/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -257,7 +258,7 @@ private fun HoldingScreenContent(
                         onClick = { onEvent(HoldingContract.HoldingViewEvent.DeleteClicked) },
                         modifier = Modifier
                             .weight(1f)
-                            .padding(vertical = MaterialTheme.spacing.small),
+                            .heightIn(min = MaterialTheme.spacing.buttonMinHeight),
                         colors = ButtonDefaults.buttonColors(
                             containerColor = MaterialTheme.colorScheme.errorContainer,
                             contentColor = MaterialTheme.colorScheme.error,
@@ -273,7 +274,7 @@ private fun HoldingScreenContent(
                     onClick = { onEvent(HoldingContract.HoldingViewEvent.ConfirmClicked) },
                     modifier = Modifier
                         .weight(1f)
-                        .padding(vertical = MaterialTheme.spacing.small),
+                        .heightIn(min = MaterialTheme.spacing.buttonMinHeight),
                     enabled = state.selectedSecurity != null &&
                               state.shares.isNotBlank() && state.pricePerShare.isNotBlank(),
                 ) {
@@ -509,9 +510,7 @@ private fun DeleteConfirmationDialog(
         onDismissRequest = onCancel,
     ) {
         Surface(
-            modifier = Modifier
-                .fillMaxWidth(0.9f)
-                .padding(MaterialTheme.spacing.large),
+            modifier = Modifier.fillMaxWidth(),
             shape = MaterialTheme.shapes.large,
             color = MaterialTheme.colorScheme.surface,
         ) {
@@ -520,12 +519,12 @@ private fun DeleteConfirmationDialog(
                 verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.medium),
             ) {
                 Text(
-                    text = "Remove Position?",
+                    text = stringResource(Res.string.dialog_remove_title),
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold,
                 )
                 Text(
-                    text = "Remove $ticker from your portfolio? This cannot be undone.",
+                    text = stringResource(Res.string.dialog_remove_message, ticker),
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Row(
@@ -536,19 +535,23 @@ private fun DeleteConfirmationDialog(
                 ) {
                     OutlinedButton(
                         onClick = onCancel,
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier
+                            .weight(1f)
+                            .heightIn(min = MaterialTheme.spacing.buttonMinHeight),
                     ) {
-                        Text("Cancel")
+                        Text(stringResource(Res.string.action_cancel))
                     }
                     Button(
                         onClick = onConfirm,
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier
+                            .weight(1f)
+                            .heightIn(min = MaterialTheme.spacing.buttonMinHeight),
                         colors = ButtonDefaults.buttonColors(
                             containerColor = MaterialTheme.colorScheme.errorContainer,
                             contentColor = MaterialTheme.colorScheme.error,
                         ),
                     ) {
-                        Text("Delete")
+                        Text(stringResource(Res.string.action_delete))
                     }
                 }
             }

--- a/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
+++ b/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
@@ -72,7 +72,7 @@ import dividox.common.ui_resources.generated.resources.label_price_per_share
 import dividox.common.ui_resources.generated.resources.label_purchase_date
 import dividox.common.ui_resources.generated.resources.label_shares
 import dividox.common.ui_resources.generated.resources.label_unknown_position
-import dividox.common.ui_resources.generated.resources.search_security_hint
+import dividox.common.ui_resources.generated.resources.holding_search_security_hint
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -304,7 +304,7 @@ private fun SearchSecurityField(
         OutlinedTextField(
             value = query,
             onValueChange = onQueryChanged,
-            label = { Text(stringResource(Res.string.search_security_hint)) },
+            label = { Text(stringResource(Res.string.holding_search_security_hint)) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
             enabled = selectedSecurity == null,

--- a/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
+++ b/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
@@ -82,6 +82,7 @@ import dividox.common.ui_resources.generated.resources.label_shares
 import dividox.common.ui_resources.generated.resources.label_unknown_position
 import dividox.common.ui_resources.generated.resources.holding_search_security_hint
 import dividox.common.ui_resources.generated.resources.security_type_all
+import dividox.common.ui_resources.generated.resources.security_type_equity
 import dividox.common.ui_resources.generated.resources.security_type_etf
 import dividox.common.ui_resources.generated.resources.security_type_fund
 import kotlinx.datetime.Instant
@@ -823,6 +824,7 @@ private fun SecurityTypeFilterRow(
 
 @Composable
 private fun SecurityType?.label(): String? = when (this) {
+    SecurityType.EQUITY -> stringResource(Res.string.security_type_equity)
     SecurityType.ETF -> stringResource(Res.string.security_type_etf)
     SecurityType.MUTUAL_FUND -> stringResource(Res.string.security_type_fund)
     null -> null

--- a/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
+++ b/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
@@ -426,6 +426,7 @@ private fun CurrencySelector(
         Currency.USD,
         Currency.EUR,
         Currency.GBP,
+        Currency.GBX,
     )
 
     Row(

--- a/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
+++ b/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -50,6 +51,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.akole.dividox.common.currency.domain.model.Currency
 import com.akole.dividox.common.ui.resources.components.DividoxTopAppBar
+import com.akole.dividox.common.ui.resources.components.ExchangeMarket
+import com.akole.dividox.common.ui.resources.components.MarketFilterRow
 import com.akole.dividox.common.ui.resources.components.SearchBar
 import com.akole.dividox.common.ui.resources.components.connectivity.ConnectivityBannerHost
 import com.akole.dividox.common.ui.resources.components.connectivity.LocalNetworkConnectivityManager
@@ -174,9 +177,13 @@ private fun HoldingScreenContent(
             query = state.searchQuery,
             results = state.searchResults,
             selectedSecurity = state.selectedSecurity,
+            selectedMarket = state.selectedMarket,
             isLoading = state.isSearching,
             onQueryChanged = { query ->
                 onEvent(HoldingContract.HoldingViewEvent.SearchQueryChanged(query))
+            },
+            onMarketSelected = { market ->
+                onEvent(HoldingContract.HoldingViewEvent.MarketFilterChanged(market))
             },
             onSecuritySelected = { quote ->
                 onEvent(HoldingContract.HoldingViewEvent.SecuritySelected(quote))
@@ -297,8 +304,10 @@ private fun SearchSecurityField(
     query: String,
     results: List<StockQuote>,
     selectedSecurity: StockQuote?,
+    selectedMarket: ExchangeMarket,
     isLoading: Boolean,
     onQueryChanged: (String) -> Unit,
+    onMarketSelected: (ExchangeMarket) -> Unit,
     onSecuritySelected: (StockQuote) -> Unit,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)) {
@@ -309,6 +318,13 @@ private fun SearchSecurityField(
             modifier = Modifier.fillMaxWidth(),
             enabled = selectedSecurity == null,
         )
+        if (selectedSecurity == null) {
+            MarketFilterRow(
+                selectedMarket = selectedMarket,
+                onMarketSelected = onMarketSelected,
+                contentPadding = PaddingValues(0.dp),
+            )
+        }
 
         if (isLoading) {
             CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))

--- a/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
+++ b/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -25,6 +27,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -60,6 +63,7 @@ import com.akole.dividox.common.ui.resources.format.formatPrice
 import com.akole.dividox.common.ui.resources.format.formatTwoDecimals
 import com.akole.dividox.common.ui.resources.theme.DividoxTheme
 import com.akole.dividox.common.ui.resources.theme.spacing
+import com.akole.dividox.component.market.domain.model.SecurityType
 import com.akole.dividox.component.market.domain.model.StockQuote
 import com.akole.dividox.component.market.domain.model.displayName
 import com.akole.dividox.component.portfolio.domain.model.HoldingId
@@ -77,6 +81,9 @@ import dividox.common.ui_resources.generated.resources.label_purchase_date
 import dividox.common.ui_resources.generated.resources.label_shares
 import dividox.common.ui_resources.generated.resources.label_unknown_position
 import dividox.common.ui_resources.generated.resources.holding_search_security_hint
+import dividox.common.ui_resources.generated.resources.security_type_all
+import dividox.common.ui_resources.generated.resources.security_type_etf
+import dividox.common.ui_resources.generated.resources.security_type_fund
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -178,12 +185,16 @@ private fun HoldingScreenContent(
             results = state.searchResults,
             selectedSecurity = state.selectedSecurity,
             selectedMarket = state.selectedMarket,
+            selectedType = state.selectedType,
             isLoading = state.isSearching,
             onQueryChanged = { query ->
                 onEvent(HoldingContract.HoldingViewEvent.SearchQueryChanged(query))
             },
             onMarketSelected = { market ->
                 onEvent(HoldingContract.HoldingViewEvent.MarketFilterChanged(market))
+            },
+            onTypeSelected = { type ->
+                onEvent(HoldingContract.HoldingViewEvent.TypeFilterChanged(type))
             },
             onSecuritySelected = { quote ->
                 onEvent(HoldingContract.HoldingViewEvent.SecuritySelected(quote))
@@ -305,9 +316,11 @@ private fun SearchSecurityField(
     results: List<StockQuote>,
     selectedSecurity: StockQuote?,
     selectedMarket: ExchangeMarket,
+    selectedType: SecurityType?,
     isLoading: Boolean,
     onQueryChanged: (String) -> Unit,
     onMarketSelected: (ExchangeMarket) -> Unit,
+    onTypeSelected: (SecurityType?) -> Unit,
     onSecuritySelected: (StockQuote) -> Unit,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small)) {
@@ -322,6 +335,11 @@ private fun SearchSecurityField(
             MarketFilterRow(
                 selectedMarket = selectedMarket,
                 onMarketSelected = onMarketSelected,
+                contentPadding = PaddingValues(0.dp),
+            )
+            SecurityTypeFilterRow(
+                selectedType = selectedType,
+                onTypeSelected = onTypeSelected,
                 contentPadding = PaddingValues(0.dp),
             )
         }
@@ -366,11 +384,24 @@ private fun SecurityResultItem(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = quote.ticker,
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.Bold,
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xSmall),
+            ) {
+                Text(
+                    text = quote.ticker,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+                val typeLabel = quote.type.label()
+                if (typeLabel != null) {
+                    Text(
+                        text = typeLabel,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
             if (quote.name != null) {
                 Text(
                     text = quote.name!!,
@@ -762,4 +793,37 @@ private fun HoldingScreenAddDarkPreview() {
             onEvent = {},
         )
     }
+}
+
+@Composable
+private fun SecurityTypeFilterRow(
+    selectedType: SecurityType?,
+    onTypeSelected: (SecurityType?) -> Unit,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+) {
+    val options: List<SecurityType?> = listOf(null) + SecurityType.entries
+    LazyRow(
+        contentPadding = contentPadding,
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small),
+    ) {
+        items(options, key = { it?.name ?: "ALL" }) { type ->
+            FilterChip(
+                selected = selectedType == type,
+                onClick = { onTypeSelected(type) },
+                label = {
+                    Text(
+                        text = type.label() ?: stringResource(Res.string.security_type_all),
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SecurityType?.label(): String? = when (this) {
+    SecurityType.ETF -> stringResource(Res.string.security_type_etf)
+    SecurityType.MUTUAL_FUND -> stringResource(Res.string.security_type_fund)
+    null -> null
 }

--- a/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingViewModel.kt
+++ b/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.launch
 
 class HoldingViewModel(
     private val holdingId: HoldingId?,
+    private val prefillTicker: String? = null,
     private val searchSecurities: SearchSecuritiesUseCase,
     private val getStockQuote: GetStockQuoteUseCase,
     private val addHolding: AddHoldingUseCase,
@@ -51,6 +52,8 @@ class HoldingViewModel(
         }
         if (holdingId != null) {
             loadExistingHolding(holdingId)
+        } else if (prefillTicker != null) {
+            prefillSecurity(prefillTicker)
         }
     }
 
@@ -135,6 +138,23 @@ class HoldingViewModel(
                 purchaseDateMillis = holding.purchaseDate,
             )
             recalculateTotal()
+        }
+    }
+
+    private fun prefillSecurity(ticker: String) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(searchQuery = ticker, isSearching = true)
+            val quote = getStockQuote(ticker).getOrNull() ?: run {
+                _state.value = _state.value.copy(isSearching = false)
+                return@launch
+            }
+            _state.value = _state.value.copy(
+                selectedSecurity = quote,
+                searchQuery = ticker,
+                searchResults = emptyList(),
+                isSearching = false,
+            )
+            checkPortfolioForExistingHolding(ticker)
         }
     }
 

--- a/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingViewModel.kt
+++ b/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingViewModel.kt
@@ -3,6 +3,7 @@ package com.akole.dividox.feature.portfolio
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.akole.dividox.common.settings.domain.usecase.ObserveAppSettingsUseCase
+import com.akole.dividox.common.ui.resources.components.ExchangeMarket
 import com.akole.dividox.component.market.domain.model.StockQuote
 import com.akole.dividox.component.market.domain.usecase.GetStockQuoteUseCase
 import com.akole.dividox.component.market.domain.usecase.SearchSecuritiesUseCase
@@ -34,6 +35,8 @@ class HoldingViewModel(
     private val observeAppSettings: ObserveAppSettingsUseCase,
 ) : ViewModel() {
 
+    private var allSearchResults: List<StockQuote> = emptyList()
+
     private val _state = MutableStateFlow(
         HoldingContract.HoldingViewState(
             mode = if (holdingId != null) HoldingContract.Mode.EDIT else HoldingContract.Mode.ADD,
@@ -62,6 +65,13 @@ class HoldingViewModel(
             is HoldingContract.HoldingViewEvent.SearchQueryChanged -> {
                 _state.value = _state.value.copy(searchQuery = event.query)
                 performSearch(event.query)
+            }
+
+            is HoldingContract.HoldingViewEvent.MarketFilterChanged -> {
+                _state.value = _state.value.copy(
+                    selectedMarket = event.market,
+                    searchResults = allSearchResults.filterByMarket(event.market),
+                )
             }
 
             is HoldingContract.HoldingViewEvent.SecuritySelected -> {
@@ -185,10 +195,12 @@ class HoldingViewModel(
         viewModelScope.launch {
             if (query.isNotBlank()) {
                 try {
+                    val market = _state.value.selectedMarket
                     _state.value = _state.value.copy(isSearching = true)
-                    val results = searchSecurities(query).getOrElse { emptyList() }
+                    val results = searchSecurities(query, market.region).getOrElse { emptyList() }
+                    allSearchResults = results
                     _state.value = _state.value.copy(
-                        searchResults = results,
+                        searchResults = results.filterByMarket(market),
                         isSearching = false,
                     )
                 } catch (e: Exception) {
@@ -196,10 +208,14 @@ class HoldingViewModel(
                     _sideEffect.send(HoldingContract.HoldingSideEffect.ShowError(e.message ?: "Search failed"))
                 }
             } else {
+                allSearchResults = emptyList()
                 _state.value = _state.value.copy(searchResults = emptyList())
             }
         }
     }
+
+    private fun List<StockQuote>.filterByMarket(market: ExchangeMarket): List<StockQuote> =
+        if (market == ExchangeMarket.ALL) this else filter { market.matches(it.exchange) }
 
     private fun recalculateTotal() {
         val shares = _state.value.shares.toDoubleOrNull() ?: 0.0

--- a/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingViewModel.kt
+++ b/feature/portfolio/src/commonMain/kotlin/com/akole/dividox/feature/portfolio/HoldingViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.akole.dividox.common.settings.domain.usecase.ObserveAppSettingsUseCase
 import com.akole.dividox.common.ui.resources.components.ExchangeMarket
+import com.akole.dividox.component.market.domain.model.SecurityType
 import com.akole.dividox.component.market.domain.model.StockQuote
 import com.akole.dividox.component.market.domain.usecase.GetStockQuoteUseCase
 import com.akole.dividox.component.market.domain.usecase.SearchSecuritiesUseCase
@@ -70,7 +71,14 @@ class HoldingViewModel(
             is HoldingContract.HoldingViewEvent.MarketFilterChanged -> {
                 _state.value = _state.value.copy(
                     selectedMarket = event.market,
-                    searchResults = allSearchResults.filterByMarket(event.market),
+                    searchResults = allSearchResults.filterByMarket(event.market).filterByType(_state.value.selectedType),
+                )
+            }
+
+            is HoldingContract.HoldingViewEvent.TypeFilterChanged -> {
+                _state.value = _state.value.copy(
+                    selectedType = event.type,
+                    searchResults = allSearchResults.filterByMarket(_state.value.selectedMarket).filterByType(event.type),
                 )
             }
 
@@ -200,7 +208,7 @@ class HoldingViewModel(
                     val results = searchSecurities(query, market.region).getOrElse { emptyList() }
                     allSearchResults = results
                     _state.value = _state.value.copy(
-                        searchResults = results.filterByMarket(market),
+                        searchResults = results.filterByMarket(market).filterByType(_state.value.selectedType),
                         isSearching = false,
                     )
                 } catch (e: Exception) {
@@ -216,6 +224,9 @@ class HoldingViewModel(
 
     private fun List<StockQuote>.filterByMarket(market: ExchangeMarket): List<StockQuote> =
         if (market == ExchangeMarket.ALL) this else filter { market.matches(it.exchange) }
+
+    private fun List<StockQuote>.filterByType(type: SecurityType?): List<StockQuote> =
+        if (type == null) this else filter { it.type == type }
 
     private fun recalculateTotal() {
         val shares = _state.value.shares.toDoubleOrNull() ?: 0.0

--- a/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/ExchangeMarket.kt
+++ b/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/ExchangeMarket.kt
@@ -1,26 +1,3 @@
 package com.akole.dividox.feature.search
 
-enum class ExchangeMarket(
-    val emoji: String,
-    val label: String,
-    val region: String?,
-    private val keywords: Set<String>,
-) {
-    ALL("🌍", "All", null, emptySet()),
-    US("🇺🇸", "US", "US", setOf("NASDAQ", "NYSE", "AMEX", "OTC", "ARCA", "PCX")),
-    UK("🇬🇧", "UK", "GB", setOf("LSE", "LONDON", "LON")),
-    DE("🇩🇪", "DE", "DE", setOf("XETRA", "FSX", "FRA", "GER")),
-    ES("🇪🇸", "ES", "ES", setOf("BME", "MCE", "MAD", "MADRID")),
-    FR("🇫🇷", "FR", "FR", setOf("PAR", "EPA", "ENX", "PARIS")),
-    IT("🇮🇹", "IT", "IT", setOf("MIL", "BIT", "MILAN")),
-    CA("🇨🇦", "CA", "CA", setOf("TSX", "CVE", "TORONTO")),
-    AU("🇦🇺", "AU", "AU", setOf("ASX", "SYDNEY")),
-    JP("🇯🇵", "JP", "JP", setOf("TSE", "OSE", "TOKYO")),
-    ;
-
-    fun matches(exchange: String?): Boolean {
-        if (this == ALL) return true
-        val upper = exchange?.uppercase() ?: return false
-        return keywords.any { upper.contains(it) }
-    }
-}
+typealias ExchangeMarket = com.akole.dividox.common.ui.resources.components.ExchangeMarket

--- a/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/ExchangeMarket.kt
+++ b/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/ExchangeMarket.kt
@@ -1,0 +1,26 @@
+package com.akole.dividox.feature.search
+
+enum class ExchangeMarket(
+    val emoji: String,
+    val label: String,
+    val region: String?,
+    private val keywords: Set<String>,
+) {
+    ALL("🌍", "All", null, emptySet()),
+    US("🇺🇸", "US", "US", setOf("NASDAQ", "NYSE", "AMEX", "OTC", "ARCA", "PCX")),
+    UK("🇬🇧", "UK", "GB", setOf("LSE", "LONDON", "LON")),
+    DE("🇩🇪", "DE", "DE", setOf("XETRA", "FSX", "FRA", "GER")),
+    ES("🇪🇸", "ES", "ES", setOf("BME", "MCE", "MAD", "MADRID")),
+    FR("🇫🇷", "FR", "FR", setOf("PAR", "EPA", "ENX", "PARIS")),
+    IT("🇮🇹", "IT", "IT", setOf("MIL", "BIT", "MILAN")),
+    CA("🇨🇦", "CA", "CA", setOf("TSX", "CVE", "TORONTO")),
+    AU("🇦🇺", "AU", "AU", setOf("ASX", "SYDNEY")),
+    JP("🇯🇵", "JP", "JP", setOf("TSE", "OSE", "TOKYO")),
+    ;
+
+    fun matches(exchange: String?): Boolean {
+        if (this == ALL) return true
+        val upper = exchange?.uppercase() ?: return false
+        return keywords.any { upper.contains(it) }
+    }
+}

--- a/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchContract.kt
+++ b/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchContract.kt
@@ -13,12 +13,14 @@ interface SearchContract {
         val watchlistedTickers: Set<String> = emptySet(),
         val isLoading: Boolean = false,
         val error: String? = null,
+        val selectedMarket: ExchangeMarket = ExchangeMarket.ALL,
     ) : ViewState
 
     sealed interface SearchViewEvent : ViewEvent {
         data class QueryChanged(val query: String) : SearchViewEvent
         data class FavouriteToggled(val ticker: String) : SearchViewEvent
         data class SecurityClicked(val ticker: String) : SearchViewEvent
+        data class MarketFilterChanged(val market: ExchangeMarket) : SearchViewEvent
         data object BackClicked : SearchViewEvent
     }
 

--- a/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchContract.kt
+++ b/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchContract.kt
@@ -3,6 +3,7 @@ package com.akole.dividox.feature.search
 import com.akole.dividox.common.mvi.SideEffect
 import com.akole.dividox.common.mvi.ViewEvent
 import com.akole.dividox.common.mvi.ViewState
+import com.akole.dividox.component.market.domain.model.SecurityType
 import com.akole.dividox.component.market.domain.model.StockQuote
 
 interface SearchContract {
@@ -14,6 +15,7 @@ interface SearchContract {
         val isLoading: Boolean = false,
         val error: String? = null,
         val selectedMarket: ExchangeMarket = ExchangeMarket.ALL,
+        val selectedType: SecurityType? = null,
     ) : ViewState
 
     sealed interface SearchViewEvent : ViewEvent {
@@ -21,6 +23,7 @@ interface SearchContract {
         data class FavouriteToggled(val ticker: String) : SearchViewEvent
         data class SecurityClicked(val ticker: String) : SearchViewEvent
         data class MarketFilterChanged(val market: ExchangeMarket) : SearchViewEvent
+        data class TypeFilterChanged(val type: SecurityType?) : SearchViewEvent
         data object BackClicked : SearchViewEvent
     }
 

--- a/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchScreen.kt
@@ -44,6 +44,7 @@ import dividox.common.ui_resources.generated.resources.search_no_results
 import dividox.common.ui_resources.generated.resources.search_placeholder_hint
 import dividox.common.ui_resources.generated.resources.search_title
 import dividox.common.ui_resources.generated.resources.security_type_all
+import dividox.common.ui_resources.generated.resources.security_type_equity
 import dividox.common.ui_resources.generated.resources.security_type_etf
 import dividox.common.ui_resources.generated.resources.security_type_fund
 import kotlinx.coroutines.flow.Flow
@@ -190,6 +191,7 @@ private fun SecurityTypeFilterRow(
 
 @Composable
 private fun SecurityType?.label(): String? = when (this) {
+    SecurityType.EQUITY -> stringResource(Res.string.security_type_equity)
     SecurityType.ETF -> stringResource(Res.string.security_type_etf)
     SecurityType.MUTUAL_FUND -> stringResource(Res.string.security_type_fund)
     null -> null

--- a/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchScreen.kt
@@ -1,13 +1,16 @@
 package com.akole.dividox.feature.search
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -29,6 +32,7 @@ import com.akole.dividox.feature.search.SearchContract.SearchSideEffect.Navigati
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.BackClicked
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.FavouriteToggled
+import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.MarketFilterChanged
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.QueryChanged
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.SecurityClicked
 import com.akole.dividox.feature.search.SearchContract.SearchViewState
@@ -84,6 +88,21 @@ fun SearchScreen(
                         ),
                     autoFocus = true,
                 )
+            }
+
+            item {
+                LazyRow(
+                    contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.medium),
+                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small),
+                ) {
+                    items(ExchangeMarket.entries, key = { it.name }) { market ->
+                        FilterChip(
+                            selected = state.selectedMarket == market,
+                            onClick = { onEvent(MarketFilterChanged(market)) },
+                            label = { Text("${market.emoji} ${market.label}") },
+                        )
+                    }
+                }
             }
 
             when {

--- a/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchScreen.kt
@@ -1,13 +1,16 @@
 package com.akole.dividox.feature.search
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -25,6 +28,7 @@ import com.akole.dividox.common.ui.resources.components.SecurityCard
 import com.akole.dividox.common.ui.resources.components.connectivity.ConnectivityBannerHost
 import com.akole.dividox.common.ui.resources.components.connectivity.LocalNetworkConnectivityManager
 import com.akole.dividox.common.ui.resources.theme.spacing
+import com.akole.dividox.component.market.domain.model.SecurityType
 import com.akole.dividox.feature.search.SearchContract.SearchSideEffect
 import com.akole.dividox.feature.search.SearchContract.SearchSideEffect.Navigation
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent
@@ -33,11 +37,15 @@ import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.Favourite
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.MarketFilterChanged
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.QueryChanged
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.SecurityClicked
+import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.TypeFilterChanged
 import com.akole.dividox.feature.search.SearchContract.SearchViewState
 import dividox.common.ui_resources.generated.resources.Res
 import dividox.common.ui_resources.generated.resources.search_no_results
 import dividox.common.ui_resources.generated.resources.search_placeholder_hint
 import dividox.common.ui_resources.generated.resources.search_title
+import dividox.common.ui_resources.generated.resources.security_type_all
+import dividox.common.ui_resources.generated.resources.security_type_etf
+import dividox.common.ui_resources.generated.resources.security_type_fund
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import org.jetbrains.compose.resources.stringResource
@@ -95,6 +103,13 @@ fun SearchScreen(
                 )
             }
 
+            item {
+                SecurityTypeFilterRow(
+                    selectedType = state.selectedType,
+                    onTypeSelected = { onEvent(TypeFilterChanged(it)) },
+                )
+            }
+
             when {
                 state.isLoading -> item {
                     Box(
@@ -130,6 +145,7 @@ fun SearchScreen(
                         isInPortfolio = false,
                         onFavoriteToggle = { onEvent(FavouriteToggled(quote.ticker)) },
                         onClick = { onEvent(SecurityClicked(quote.ticker)) },
+                        securityType = quote.type.label(),
                         modifier = Modifier.padding(
                             horizontal = MaterialTheme.spacing.medium,
                             vertical = MaterialTheme.spacing.xSmall,
@@ -145,4 +161,36 @@ fun SearchScreen(
             }
         }
     }
+}
+
+@Composable
+private fun SecurityTypeFilterRow(
+    selectedType: SecurityType?,
+    onTypeSelected: (SecurityType?) -> Unit,
+) {
+    val options: List<SecurityType?> = listOf(null) + SecurityType.entries
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.medium),
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small),
+    ) {
+        items(options, key = { it?.name ?: "ALL" }) { type ->
+            FilterChip(
+                selected = selectedType == type,
+                onClick = { onTypeSelected(type) },
+                label = {
+                    Text(
+                        text = type.label() ?: stringResource(Res.string.security_type_all),
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SecurityType?.label(): String? = when (this) {
+    SecurityType.ETF -> stringResource(Res.string.security_type_etf)
+    SecurityType.MUTUAL_FUND -> stringResource(Res.string.security_type_fund)
+    null -> null
 }

--- a/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchScreen.kt
@@ -1,16 +1,13 @@
 package com.akole.dividox.feature.search
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -22,6 +19,7 @@ import com.akole.dividox.common.currency.domain.model.Currency
 import com.akole.dividox.common.mvi.CollectSideEffect
 import com.akole.dividox.common.ui.resources.components.DisclaimerBanner
 import com.akole.dividox.common.ui.resources.components.DividoxTopAppBar
+import com.akole.dividox.common.ui.resources.components.MarketFilterRow
 import com.akole.dividox.common.ui.resources.components.SearchBar
 import com.akole.dividox.common.ui.resources.components.SecurityCard
 import com.akole.dividox.common.ui.resources.components.connectivity.ConnectivityBannerHost
@@ -91,18 +89,10 @@ fun SearchScreen(
             }
 
             item {
-                LazyRow(
-                    contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.medium),
-                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.small),
-                ) {
-                    items(ExchangeMarket.entries, key = { it.name }) { market ->
-                        FilterChip(
-                            selected = state.selectedMarket == market,
-                            onClick = { onEvent(MarketFilterChanged(market)) },
-                            label = { Text("${market.emoji} ${market.label}") },
-                        )
-                    }
-                }
+                MarketFilterRow(
+                    selectedMarket = state.selectedMarket,
+                    onMarketSelected = { onEvent(MarketFilterChanged(it)) },
+                )
             }
 
             when {

--- a/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchViewModel.kt
@@ -13,9 +13,11 @@ import com.akole.dividox.feature.search.SearchContract.SearchSideEffect
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.BackClicked
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.FavouriteToggled
+import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.MarketFilterChanged
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.QueryChanged
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.SecurityClicked
 import com.akole.dividox.feature.search.SearchContract.SearchViewState
+import com.akole.dividox.component.market.domain.model.StockQuote
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
@@ -31,6 +33,7 @@ class SearchViewModel(
     MVI<SearchViewState, SearchViewEvent, SearchSideEffect> by mvi(SearchViewState()) {
 
     private val queryFlow = MutableStateFlow("")
+    private var allResults: List<StockQuote> = emptyList()
 
     init {
         observeSearch()
@@ -44,6 +47,14 @@ class SearchViewModel(
                 updateViewState { copy(query = viewEvent.query) }
                 queryFlow.value = viewEvent.query
             }
+            is MarketFilterChanged -> {
+                updateViewState {
+                    copy(
+                        selectedMarket = viewEvent.market,
+                        results = allResults.filterByMarket(viewEvent.market),
+                    )
+                }
+            }
             is FavouriteToggled -> toggleFavourite(viewEvent.ticker)
             is SecurityClicked -> viewModelScope.emitSideEffect(
                 SearchSideEffect.Navigation.NavigateToSecurity(viewEvent.ticker)
@@ -56,20 +67,27 @@ class SearchViewModel(
         viewModelScope.launch {
             queryFlow.debounce(250L).collectLatest { query ->
                 if (query.isBlank()) {
+                    allResults = emptyList()
                     updateViewState { copy(results = emptyList(), isLoading = false, error = null) }
                     return@collectLatest
                 }
                 updateViewState { copy(isLoading = true, error = null) }
-                searchSecurities(query)
+                val market = viewState.value.selectedMarket
+                searchSecurities(query, market.region)
                     .onSuccess { results ->
-                        updateViewState { copy(results = results, isLoading = false) }
+                        allResults = results
+                        updateViewState { copy(results = results.filterByMarket(market), isLoading = false) }
                     }
                     .onFailure { e ->
+                        allResults = emptyList()
                         updateViewState { copy(results = emptyList(), isLoading = false, error = e.message) }
                     }
             }
         }
     }
+
+    private fun List<StockQuote>.filterByMarket(market: ExchangeMarket): List<StockQuote> =
+        if (market == ExchangeMarket.ALL) this else filter { market.matches(it.exchange) }
 
     private fun observeWatchlist() {
         viewModelScope.launch {

--- a/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/akole/dividox/feature/search/SearchViewModel.kt
@@ -17,7 +17,9 @@ import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.MarketFil
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.QueryChanged
 import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.SecurityClicked
 import com.akole.dividox.feature.search.SearchContract.SearchViewState
+import com.akole.dividox.component.market.domain.model.SecurityType
 import com.akole.dividox.component.market.domain.model.StockQuote
+import com.akole.dividox.feature.search.SearchContract.SearchViewEvent.TypeFilterChanged
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
@@ -51,7 +53,15 @@ class SearchViewModel(
                 updateViewState {
                     copy(
                         selectedMarket = viewEvent.market,
-                        results = allResults.filterByMarket(viewEvent.market),
+                        results = allResults.filterByMarket(viewEvent.market).filterByType(selectedType),
+                    )
+                }
+            }
+            is TypeFilterChanged -> {
+                updateViewState {
+                    copy(
+                        selectedType = viewEvent.type,
+                        results = allResults.filterByMarket(selectedMarket).filterByType(viewEvent.type),
                     )
                 }
             }
@@ -76,7 +86,8 @@ class SearchViewModel(
                 searchSecurities(query, market.region)
                     .onSuccess { results ->
                         allResults = results
-                        updateViewState { copy(results = results.filterByMarket(market), isLoading = false) }
+                        val type = viewState.value.selectedType
+                        updateViewState { copy(results = results.filterByMarket(market).filterByType(type), isLoading = false) }
                     }
                     .onFailure { e ->
                         allResults = emptyList()
@@ -88,6 +99,9 @@ class SearchViewModel(
 
     private fun List<StockQuote>.filterByMarket(market: ExchangeMarket): List<StockQuote> =
         if (market == ExchangeMarket.ALL) this else filter { market.matches(it.exchange) }
+
+    private fun List<StockQuote>.filterByType(type: SecurityType?): List<StockQuote> =
+        if (type == null) this else filter { it.type == type }
 
     private fun observeWatchlist() {
         viewModelScope.launch {

--- a/feature/search/src/jvmTest/kotlin/com/akole/dividox/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/jvmTest/kotlin/com/akole/dividox/feature/search/SearchViewModelTest.kt
@@ -52,7 +52,7 @@ class SearchViewModelTest {
         Dispatchers.setMain(testDispatcher)
         every { getWatchlist() } returns emptyFlow()
         every { connectivityManager.observeConnectivity() } returns emptyFlow()
-        coEvery { searchSecurities(any()) } returns Result.success(emptyList())
+        coEvery { searchSecurities(any(), null) } returns Result.success(emptyList())
         coEvery { addToWatchlist(any()) } just Runs
         coEvery { removeFromWatchlist(any()) } just Runs
     }
@@ -95,7 +95,7 @@ class SearchViewModelTest {
         advanceTimeBy(100)
 
         // THEN
-        coVerify(exactly = 0) { searchSecurities(any()) }
+        coVerify(exactly = 0) { searchSecurities(any(), null) }
     }
 
     @Test
@@ -109,7 +109,7 @@ class SearchViewModelTest {
         advanceUntilIdle()
 
         // THEN
-        coVerify { searchSecurities("AAPL") }
+        coVerify { searchSecurities("AAPL", null) }
     }
 
     @Test
@@ -127,7 +127,7 @@ class SearchViewModelTest {
         advanceUntilIdle()
 
         // THEN
-        coVerify(exactly = 1) { searchSecurities("AAPL") }
+        coVerify(exactly = 1) { searchSecurities("AAPL", null) }
     }
 
     // ─── Results ──────────────────────────────────────────────────────────────
@@ -136,7 +136,7 @@ class SearchViewModelTest {
     fun `SHOULD populate results WHEN searchSecurities returns quotes GIVEN query`() = runTest(testScheduler) {
         // GIVEN
         val quote = aQuote("AAPL")
-        coEvery { searchSecurities("AAPL") } returns Result.success(listOf(quote))
+        coEvery { searchSecurities("AAPL", null) } returns Result.success(listOf(quote))
         val vm = viewModel()
 
         // WHEN
@@ -152,7 +152,7 @@ class SearchViewModelTest {
     @Test
     fun `SHOULD clear results WHEN query is cleared GIVEN previous results`() = runTest(testScheduler) {
         // GIVEN
-        coEvery { searchSecurities("AAPL") } returns Result.success(listOf(aQuote("AAPL")))
+        coEvery { searchSecurities("AAPL", null) } returns Result.success(listOf(aQuote("AAPL")))
         val vm = viewModel()
         vm.onViewEvent(SearchViewEvent.QueryChanged("AAPL"))
         advanceTimeBy(250)

--- a/integration/security/build.gradle.kts
+++ b/integration/security/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.kotlinx.coroutines.core)
+            implementation(projects.common.currency)
             implementation(projects.component.portfolio)
             implementation(projects.component.market)
             implementation(projects.component.watchlist)

--- a/integration/security/src/commonMain/kotlin/com/akole/dividox/integration/security/domain/usecase/GetPortfolioSummaryUseCase.kt
+++ b/integration/security/src/commonMain/kotlin/com/akole/dividox/integration/security/domain/usecase/GetPortfolioSummaryUseCase.kt
@@ -3,6 +3,7 @@ package com.akole.dividox.integration.security.domain.usecase
 import com.akole.dividox.common.currency.CurrencyConverter
 import com.akole.dividox.common.currency.domain.model.Currency
 import com.akole.dividox.integration.security.domain.model.PortfolioSummary
+import com.akole.dividox.integration.security.domain.model.SecurityHolding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -18,8 +19,10 @@ class GetPortfolioSummaryUseCase(
     private val getPortfolioWithQuotesUseCase: GetPortfolioWithQuotesUseCase,
     private val currencyConverter: CurrencyConverter,
 ) {
-    operator fun invoke(): Flow<PortfolioSummary> =
-        getPortfolioWithQuotesUseCase().map { securityHoldings ->
+    operator fun invoke(): Flow<PortfolioSummary> = invoke(getPortfolioWithQuotesUseCase())
+
+    operator fun invoke(portfolioFlow: Flow<List<SecurityHolding>>): Flow<PortfolioSummary> =
+        portfolioFlow.map { securityHoldings ->
             if (securityHoldings.isEmpty()) {
                 return@map PortfolioSummary(
                     totalValue = 0.0,

--- a/integration/security/src/commonMain/kotlin/com/akole/dividox/integration/security/domain/usecase/GetPortfolioSummaryUseCase.kt
+++ b/integration/security/src/commonMain/kotlin/com/akole/dividox/integration/security/domain/usecase/GetPortfolioSummaryUseCase.kt
@@ -1,5 +1,7 @@
 package com.akole.dividox.integration.security.domain.usecase
 
+import com.akole.dividox.common.currency.CurrencyConverter
+import com.akole.dividox.common.currency.domain.model.Currency
 import com.akole.dividox.integration.security.domain.model.PortfolioSummary
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -7,11 +9,14 @@ import kotlinx.coroutines.flow.map
 /**
  * Aggregates all enriched portfolio holdings into a single [PortfolioSummary].
  *
- * Delegates the per-holding enrichment to [GetPortfolioWithQuotesUseCase] and then
- * performs a single-pass fold over the resulting list.
+ * All monetary values are normalized to USD before summing, so that portfolios with
+ * mixed-currency holdings (e.g. USD + EUR stocks) produce a correct total. The caller
+ * is expected to convert the USD-denominated summary to the user's display currency via
+ * [DashboardCurrencyExtensions.convertSummary].
  */
 class GetPortfolioSummaryUseCase(
     private val getPortfolioWithQuotesUseCase: GetPortfolioWithQuotesUseCase,
+    private val currencyConverter: CurrencyConverter,
 ) {
     operator fun invoke(): Flow<PortfolioSummary> =
         getPortfolioWithQuotesUseCase().map { securityHoldings ->
@@ -31,13 +36,23 @@ class GetPortfolioSummaryUseCase(
             var dividendsCollected = 0.0
 
             securityHoldings.forEach { sh ->
-                val currentValue = sh.holding.shares * sh.quote.price
-                val costBasis = sh.holding.shares * sh.holding.purchasePrice
+                val quoteCurrency = Currency.entries.firstOrNull { it.code == sh.quote.currency } ?: Currency.USD
+
+                val rawCurrentValue = sh.holding.shares * sh.quote.price
+                val currentValue = currencyConverter.convert(rawCurrentValue, quoteCurrency, Currency.USD)
+                    .getOrElse { rawCurrentValue }
+
+                val rawCostBasis = sh.holding.shares * sh.holding.purchasePrice
+                val costBasis = currencyConverter.convert(rawCostBasis, sh.holding.purchaseCurrency, Currency.USD)
+                    .getOrElse { rawCostBasis }
+
                 totalValue += currentValue
                 totalCostBasis += costBasis
 
                 val annualPayout = sh.dividendInfo?.annualPayout ?: 0.0
-                dividendsCollected += sh.holding.shares * annualPayout
+                val rawDividends = sh.holding.shares * annualPayout
+                dividendsCollected += currencyConverter.convert(rawDividends, quoteCurrency, Currency.USD)
+                    .getOrElse { rawDividends }
 
                 val yieldContribution = sh.dividendInfo?.yield ?: 0.0
                 weightedYield += yieldContribution * currentValue

--- a/integration/security/src/commonMain/kotlin/com/akole/dividox/integration/security/domain/usecase/GetPortfolioWithQuotesUseCase.kt
+++ b/integration/security/src/commonMain/kotlin/com/akole/dividox/integration/security/domain/usecase/GetPortfolioWithQuotesUseCase.kt
@@ -1,5 +1,6 @@
 package com.akole.dividox.integration.security.domain.usecase
 
+import com.akole.dividox.common.currency.CurrencyConverter
 import com.akole.dividox.common.currency.domain.model.Currency
 import com.akole.dividox.component.market.domain.model.StockQuote
 import com.akole.dividox.component.market.domain.usecase.GetDividendInfoUseCase
@@ -36,6 +37,7 @@ class GetPortfolioWithQuotesUseCase(
     private val getPortfolioUseCase: GetPortfolioUseCase,
     private val getMultipleQuotesUseCase: GetMultipleQuotesUseCase,
     private val getDividendInfoUseCase: GetDividendInfoUseCase,
+    private val currencyConverter: CurrencyConverter,
 ) {
     operator fun invoke(): Flow<List<SecurityHolding>> =
         getPortfolioUseCase.execute()
@@ -63,17 +65,17 @@ class GetPortfolioWithQuotesUseCase(
                                 async {
                                     val quote = quoteByTicker[holding.tickerId]!!
                                     val dividendInfo = getDividendInfoUseCase(holding.tickerId).getOrNull()
-                                    val rawCostBasis = holding.shares * holding.purchasePrice
-                                    // Normalize GBX (pence) to GBP so gain% is comparable to the
-                                    // normalized quote price (always in GBP after ChartMapper fix).
-                                    val costBasis = if (holding.purchaseCurrency == Currency.GBX) {
-                                        rawCostBasis * 0.01
-                                    } else {
-                                        rawCostBasis
-                                    }
-                                    val currentValue = holding.shares * quote.price
-                                    val totalGainPercent = if (costBasis != 0.0) {
-                                        (currentValue - costBasis) / costBasis * 100.0
+                                    // Normalize purchase price to quote.currency so gain% is
+                                    // comparable regardless of the currency the user bought in.
+                                    val quoteCurrency = Currency.entries
+                                        .firstOrNull { it.code == quote.currency } ?: Currency.USD
+                                    val purchasePriceNorm = currencyConverter.convert(
+                                        holding.purchasePrice,
+                                        holding.purchaseCurrency,
+                                        quoteCurrency,
+                                    ).getOrElse { holding.purchasePrice }
+                                    val totalGainPercent = if (purchasePriceNorm != 0.0) {
+                                        (quote.price - purchasePriceNorm) / purchasePriceNorm * 100.0
                                     } else {
                                         0.0
                                     }

--- a/integration/security/src/commonMain/kotlin/com/akole/dividox/integration/security/domain/usecase/GetPortfolioWithQuotesUseCase.kt
+++ b/integration/security/src/commonMain/kotlin/com/akole/dividox/integration/security/domain/usecase/GetPortfolioWithQuotesUseCase.kt
@@ -1,5 +1,6 @@
 package com.akole.dividox.integration.security.domain.usecase
 
+import com.akole.dividox.common.currency.domain.model.Currency
 import com.akole.dividox.component.market.domain.model.StockQuote
 import com.akole.dividox.component.market.domain.usecase.GetDividendInfoUseCase
 import com.akole.dividox.component.market.domain.usecase.GetMultipleQuotesUseCase
@@ -62,7 +63,14 @@ class GetPortfolioWithQuotesUseCase(
                                 async {
                                     val quote = quoteByTicker[holding.tickerId]!!
                                     val dividendInfo = getDividendInfoUseCase(holding.tickerId).getOrNull()
-                                    val costBasis = holding.shares * holding.purchasePrice
+                                    val rawCostBasis = holding.shares * holding.purchasePrice
+                                    // Normalize GBX (pence) to GBP so gain% is comparable to the
+                                    // normalized quote price (always in GBP after ChartMapper fix).
+                                    val costBasis = if (holding.purchaseCurrency == Currency.GBX) {
+                                        rawCostBasis * 0.01
+                                    } else {
+                                        rawCostBasis
+                                    }
                                     val currentValue = holding.shares * quote.price
                                     val totalGainPercent = if (costBasis != 0.0) {
                                         (currentValue - costBasis) / costBasis * 100.0

--- a/integration/security/src/commonMain/kotlin/com/akole/dividox/integration/security/domain/usecase/GetPortfolioWithQuotesUseCase.kt
+++ b/integration/security/src/commonMain/kotlin/com/akole/dividox/integration/security/domain/usecase/GetPortfolioWithQuotesUseCase.kt
@@ -2,13 +2,10 @@ package com.akole.dividox.integration.security.domain.usecase
 
 import com.akole.dividox.common.currency.CurrencyConverter
 import com.akole.dividox.common.currency.domain.model.Currency
-import com.akole.dividox.component.market.domain.model.StockQuote
 import com.akole.dividox.component.market.domain.usecase.GetDividendInfoUseCase
 import com.akole.dividox.component.market.domain.usecase.GetMultipleQuotesUseCase
-import com.akole.dividox.component.portfolio.domain.model.Holding
 import com.akole.dividox.component.portfolio.domain.usecase.GetPortfolioUseCase
 import com.akole.dividox.integration.security.domain.model.SecurityHolding
-import kotlin.time.Clock
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -50,10 +47,8 @@ class GetPortfolioWithQuotesUseCase(
                     val quotes = getMultipleQuotesUseCase(tickers).getOrNull()
 
                     if (quotes == null || (quotes.isEmpty() && tickers.isNotEmpty())) {
-                        // Offline or API unavailable: emit holdings with purchase price as
-                        // fallback so the portfolio list is visible. isLive=false lets the UI
-                        // hide price-sensitive fields (gain %, current value).
-                        emit(holdings.map { it.toOfflineFallback() })
+                        // Don't emit stale/fallback data — keep skeleton visible until real
+                        // quotes arrive. retryWhen handles back-off and re-fetch.
                         throw IllegalStateException("Market quotes unavailable, will retry")
                     }
 
@@ -95,17 +90,4 @@ class GetPortfolioWithQuotesUseCase(
                 }
             }
 
-    private fun Holding.toOfflineFallback(): SecurityHolding = SecurityHolding(
-        holding = this,
-        quote = StockQuote(
-            ticker = tickerId,
-            price = purchasePrice,
-            change = 0.0,
-            changePercent = 0.0,
-            currency = "USD",
-            lastUpdated = Clock.System.now(),
-        ),
-        dividendInfo = null,
-        totalGainPercent = 0.0,
-    )
 }

--- a/integration/security/src/commonTest/kotlin/com/akole/dividox/integration/security/FakeMarketRepository.kt
+++ b/integration/security/src/commonTest/kotlin/com/akole/dividox/integration/security/FakeMarketRepository.kt
@@ -65,6 +65,12 @@ class FakeMarketRepository : MarketRepository {
     override fun getPriceHistory(ticker: String, period: ChartPeriod): Flow<List<PricePoint>> =
         flowOf(priceHistories[ticker] ?: emptyList())
 
+    override suspend fun getHistoricalDividendEvents(
+        ticker: String,
+        range: com.akole.dividox.component.market.domain.model.DividendHistoryRange,
+    ): Result<List<com.akole.dividox.component.market.domain.model.MarketDividendEvent>> =
+        Result.success(emptyList())
+
     override suspend fun searchSecurities(query: String): Result<List<StockQuote>> =
         Result.success(emptyList())
 

--- a/integration/security/src/commonTest/kotlin/com/akole/dividox/integration/security/usecase/GetPortfolioSummaryUseCaseTest.kt
+++ b/integration/security/src/commonTest/kotlin/com/akole/dividox/integration/security/usecase/GetPortfolioSummaryUseCaseTest.kt
@@ -1,5 +1,11 @@
 package com.akole.dividox.integration.security.usecase
 
+import com.akole.dividox.common.currency.CurrencyConverter
+import com.akole.dividox.common.currency.domain.model.Currency
+import com.akole.dividox.common.currency.domain.model.ExchangeRates
+import com.akole.dividox.common.currency.domain.repository.ExchangeRateRepository
+import com.akole.dividox.common.currency.domain.usecase.GetExchangeRatesUseCase
+import kotlinx.datetime.LocalDate
 import com.akole.dividox.component.market.domain.usecase.GetDividendInfoUseCase
 import com.akole.dividox.component.market.domain.usecase.GetMultipleQuotesUseCase
 import com.akole.dividox.component.portfolio.domain.usecase.GetPortfolioUseCase
@@ -23,7 +29,23 @@ class GetPortfolioSummaryUseCaseTest {
         getDividendInfoUseCase = GetDividendInfoUseCase(marketRepo),
     )
 
-    private val sut = GetPortfolioSummaryUseCase(getPortfolioWithQuotesUseCase)
+    // Identity rates — returns 1:1 for all pairs. USD→USD short-circuits before calling this.
+    private val currencyConverter = CurrencyConverter(
+        GetExchangeRatesUseCase(
+            object : ExchangeRateRepository {
+                override suspend fun getExchangeRates(base: Currency): Result<ExchangeRates> =
+                    Result.success(
+                        ExchangeRates(
+                            base = base,
+                            date = LocalDate(2024, 1, 1),
+                            rates = Currency.entries.associateWith { 1.0 },
+                        )
+                    )
+            }
+        )
+    )
+
+    private val sut = GetPortfolioSummaryUseCase(getPortfolioWithQuotesUseCase, currencyConverter)
 
     @Test
     fun `SHOULD emit zero summary WHEN portfolio is empty GIVEN no holdings`() = runTest {

--- a/integration/security/src/commonTest/kotlin/com/akole/dividox/integration/security/usecase/GetPortfolioSummaryUseCaseTest.kt
+++ b/integration/security/src/commonTest/kotlin/com/akole/dividox/integration/security/usecase/GetPortfolioSummaryUseCaseTest.kt
@@ -23,12 +23,6 @@ class GetPortfolioSummaryUseCaseTest {
     private val portfolioRepo = FakePortfolioRepository()
     private val marketRepo = FakeMarketRepository()
 
-    private val getPortfolioWithQuotesUseCase = GetPortfolioWithQuotesUseCase(
-        getPortfolioUseCase = GetPortfolioUseCase(portfolioRepo),
-        getMultipleQuotesUseCase = GetMultipleQuotesUseCase(marketRepo),
-        getDividendInfoUseCase = GetDividendInfoUseCase(marketRepo),
-    )
-
     // Identity rates — returns 1:1 for all pairs. USD→USD short-circuits before calling this.
     private val currencyConverter = CurrencyConverter(
         GetExchangeRatesUseCase(
@@ -43,6 +37,13 @@ class GetPortfolioSummaryUseCaseTest {
                     )
             }
         )
+    )
+
+    private val getPortfolioWithQuotesUseCase = GetPortfolioWithQuotesUseCase(
+        getPortfolioUseCase = GetPortfolioUseCase(portfolioRepo),
+        getMultipleQuotesUseCase = GetMultipleQuotesUseCase(marketRepo),
+        getDividendInfoUseCase = GetDividendInfoUseCase(marketRepo),
+        currencyConverter = currencyConverter,
     )
 
     private val sut = GetPortfolioSummaryUseCase(getPortfolioWithQuotesUseCase, currencyConverter)

--- a/integration/security/src/commonTest/kotlin/com/akole/dividox/integration/security/usecase/GetPortfolioWithQuotesUseCaseTest.kt
+++ b/integration/security/src/commonTest/kotlin/com/akole/dividox/integration/security/usecase/GetPortfolioWithQuotesUseCaseTest.kt
@@ -90,16 +90,23 @@ class GetPortfolioWithQuotesUseCaseTest {
 
     @Test
     fun `SHOULD exclude holding WHEN quote fetch fails GIVEN unavailable ticker`() = runTest {
-        // GIVEN — quote not registered → getMultipleQuotes returns empty
-        val holding = FakePortfolioRepository.holding(tickerId = "UNKNOWN")
-        portfolioRepo.setHoldings(listOf(holding))
-        // No quote set for UNKNOWN — FakeMarketRepository.getMultipleQuotes returns empty list
+        // GIVEN — two holdings, only AAPL has a quote; UNKNOWN is excluded from the result
+        portfolioRepo.setHoldings(
+            listOf(
+                FakePortfolioRepository.holding(id = "h1", tickerId = "AAPL", shares = 10.0, purchasePrice = 100.0),
+                FakePortfolioRepository.holding(id = "h2", tickerId = "UNKNOWN", shares = 5.0, purchasePrice = 50.0),
+            ),
+        )
+        marketRepo.setQuote("AAPL", FakeMarketRepository.quote(ticker = "AAPL", price = 150.0))
+        marketRepo.setDividendInfo("AAPL", FakeMarketRepository.dividendInfo("AAPL"))
+        // No quote set for UNKNOWN → excluded by filter in GetPortfolioWithQuotesUseCase
 
         // WHEN
         val result = sut().first()
 
-        // THEN — no SecurityHolding emitted because quote is missing
-        assertTrue(result.isEmpty())
+        // THEN — only AAPL holding emitted; UNKNOWN is excluded because its quote is missing
+        assertEquals(1, result.size)
+        assertEquals("AAPL", result.first().holding.tickerId)
     }
 
     @Test

--- a/integration/security/src/commonTest/kotlin/com/akole/dividox/integration/security/usecase/GetPortfolioWithQuotesUseCaseTest.kt
+++ b/integration/security/src/commonTest/kotlin/com/akole/dividox/integration/security/usecase/GetPortfolioWithQuotesUseCaseTest.kt
@@ -1,5 +1,10 @@
 package com.akole.dividox.integration.security.usecase
 
+import com.akole.dividox.common.currency.CurrencyConverter
+import com.akole.dividox.common.currency.domain.model.Currency
+import com.akole.dividox.common.currency.domain.model.ExchangeRates
+import com.akole.dividox.common.currency.domain.repository.ExchangeRateRepository
+import com.akole.dividox.common.currency.domain.usecase.GetExchangeRatesUseCase
 import com.akole.dividox.component.market.domain.usecase.GetDividendInfoUseCase
 import com.akole.dividox.component.market.domain.usecase.GetMultipleQuotesUseCase
 import com.akole.dividox.component.portfolio.domain.usecase.GetPortfolioUseCase
@@ -8,6 +13,7 @@ import com.akole.dividox.integration.security.FakePortfolioRepository
 import com.akole.dividox.integration.security.domain.usecase.GetPortfolioWithQuotesUseCase
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -22,10 +28,27 @@ class GetPortfolioWithQuotesUseCaseTest {
     private val getMultipleQuotesUseCase = GetMultipleQuotesUseCase(marketRepo)
     private val getDividendInfoUseCase = GetDividendInfoUseCase(marketRepo)
 
+    // Identity rates: all currencies convert 1:1. USD↔USD short-circuits anyway.
+    private val currencyConverter = CurrencyConverter(
+        GetExchangeRatesUseCase(
+            object : ExchangeRateRepository {
+                override suspend fun getExchangeRates(base: Currency): Result<ExchangeRates> =
+                    Result.success(
+                        ExchangeRates(
+                            base = base,
+                            date = LocalDate(2024, 1, 1),
+                            rates = Currency.entries.associateWith { 1.0 },
+                        )
+                    )
+            }
+        )
+    )
+
     private val sut = GetPortfolioWithQuotesUseCase(
         getPortfolioUseCase = getPortfolioUseCase,
         getMultipleQuotesUseCase = getMultipleQuotesUseCase,
         getDividendInfoUseCase = getDividendInfoUseCase,
+        currencyConverter = currencyConverter,
     )
 
     @Test


### PR DESCRIPTION
DVX-TK-027
## Dashboard Loading & API Parallelisation

  ### Problem

  With 30+ holdings, the Dashboard showed `0,00` values briefly before real data appeared.
  API calls for quotes and dividends ran sequentially, hitting Yahoo Finance rate limits and making the first load slow.

  ### Changes

  #### `MarketRepositoryImpl`

  - Added `Semaphore(MAX_CONCURRENT_REQUESTS = 8)` shared across all Yahoo Finance calls — prevents rate-limiting on large portfolios
  - `getMultipleQuotes`: quotes now fetch in parallel (`async/await`) behind the semaphore; per-ticker `runCatching` means one failed ticker no longer kills the whole batch
  - `getDividendInfo`: also guarded by the semaphore so dividend fetches don't flood the API alongside quote fetches

  #### `GetPortfolioSummaryUseCase`

  - Added `invoke(portfolioFlow: Flow<List<SecurityHolding>>)` overload so the ViewModel can pass a shared upstream and avoid triggering a second set of API calls

  #### `GetPortfolioWithQuotesUseCase`

  - Removed offline fallback — no longer emits stale `0,00` data when quotes are unavailable; `retryWhen` backoff handles re-fetching

  #### `DashboardViewModel`

  - `portfolioShared` — single upstream shared between summary and gain coroutines via `shareIn(WhileSubscribed, replay=1)`, eliminating duplicate API calls
  - `.filter { it.isNotEmpty() }` on `portfolioShared` — discards the initial empty emission before quotes arrive, so summary and gain only compute with real data
  - `summaryFlow: MutableStateFlow<PortfolioSummary?>(null)` — starts `null`, fed by a dedicated coroutine; skeleton stays until first real summary arrives
  - `periodGainFlow: MutableStateFlow<Pair<Double, Double>?>(null)` — starts `null`, set once gain computation completes
  - `isLoading = summary == null || gainPair == null || summary.totalValue == 0.0` — skeleton stays visible until all three conditions clear: summary received, gain computed, total value non-zero